### PR TITLE
Add display name support

### DIFF
--- a/prisma/migrations/20260510100428_add_display_name_for_user_model/migration.sql
+++ b/prisma/migrations/20260510100428_add_display_name_for_user_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "displayName" VARCHAR(20);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,10 +173,11 @@ enum AuthProvider {
 }
 
 model User {
-  id       String  @id @default(uuid())
-  username String  @unique @db.VarChar(20)
-  email    String  @unique @db.VarChar(345)
-  password String? @db.VarChar(60)
+  id          String  @id @default(uuid())
+  username    String  @unique @db.VarChar(20)
+  displayName String? @db.VarChar(20)
+  email       String  @unique @db.VarChar(345)
+  password    String? @db.VarChar(60)
 
   profilePictureUrl String?
   profilePictureKey String?

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -130,7 +130,7 @@ const deleteProfilePicture = asyncHandler(
 const updateProfile = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user.id;
-    const { username, bio } = req.body;
+    const { displayName, bio } = req.body;
 
     const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
     const foundUser = cachedUser
@@ -139,20 +139,19 @@ const updateProfile = asyncHandler(
 
     if (!foundUser) throw new HttpError("User not found", 404);
 
-    if (username === foundUser.username) {
-      if (bio === foundUser.bio)
-        throw new HttpError("Username and bio already used", 400);
-    } else {
-      const usernameExists = await prisma.user.findUnique({
-        where: { username },
-      });
+    const data: { displayName?: string | null; bio?: string } = {};
 
-      if (usernameExists) throw new HttpError("Username is already taken", 400);
-    }
+    if (displayName !== undefined && displayName !== foundUser.displayName)
+      data.displayName = displayName;
+
+    if (bio !== undefined && bio !== foundUser.bio) data.bio = bio;
+
+    if (Object.keys(data).length === 0)
+      throw new HttpError("Profile already up to date", 400);
 
     const updatedUser = await prisma.user.update({
       where: { id: userId },
-      data: { username, bio },
+      data,
     });
 
     await getRedisCacheClient().set(

--- a/src/graphql/typeDefs/user.typeDefs.ts
+++ b/src/graphql/typeDefs/user.typeDefs.ts
@@ -12,6 +12,7 @@ const userTypeDefs = gql`
   type User {
     id: String!
     username: String!
+    displayName: String
     email: String!
     profilePictureKey: String
     profilePictureUrl: String

--- a/src/validations/user.schema.ts
+++ b/src/validations/user.schema.ts
@@ -2,39 +2,48 @@ import { createRequire } from "module";
 
 import z from "zod";
 
-import { Interest } from "../generated/prisma/index.js";
-
 const require = createRequire(import.meta.url);
 const leoProfanity = require("leo-profanity");
 
 const normalize = (text: string) => text.replace(/[^a-zA-Z]+/g, " ");
 
+const displayNameSchema = z
+  .string()
+  .min(3, "Display name must be at least 3 characters")
+  .max(20, "Display name must be at most 20 characters")
+  .regex(
+    /^[a-zA-Z0-9_. ]+$/,
+    "Only letters, numbers, spaces, underscores, and dots allowed",
+  )
+  .refine((displayName) => displayName.trim().length > 0, {
+    message: "Display name cannot be only spaces",
+  })
+  .refine((displayName) => !leoProfanity.check(normalize(displayName)), {
+    message: "Display name contains inappropriate language",
+  });
+
 const updateProfilePictureSchema = z.object({
   objectKey: z.string().nonempty("objectKey is required"),
 });
 
-const updateProfileSchema = z.object({
-  username: z
-    .string()
-    .min(3, "Username must be at least 3 characters")
-    .max(20, "Username must be at most 20 characters")
-    .regex(
-      /^[a-zA-Z0-9_. ]+$/,
-      "Only letters, numbers, spaces, underscores, and dots allowed",
-    )
-    .refine((username) => username.trim().length > 0, {
-      message: "Username cannot be only spaces",
-    })
-    .refine((username) => !leoProfanity.check(normalize(username)), {
-      message: "Username contains inappropriate language",
-    }),
-  bio: z
-    .string()
-    .max(200, "Bio must be at most 200 characters")
-    .refine((bio) => (bio ? !leoProfanity.check(bio) : true), {
-      message: "Bio contains inappropriate language",
-    }),
-});
+const updateProfileSchema = z
+  .object({
+    displayName: displayNameSchema.nullable().optional(),
+    bio: z
+      .string()
+      .max(200, "Bio must be at most 200 characters")
+      .refine((bio) => (bio ? !leoProfanity.check(bio) : true), {
+        message: "Bio contains inappropriate language",
+      })
+      .optional(),
+  })
+  .strict()
+  .refine(
+    ({ displayName, bio }) => displayName !== undefined || bio !== undefined,
+    {
+      message: "At least one of displayName or bio is required",
+    },
+  );
 
 const updateNotificationSettingsSchema = z
   .object({


### PR DESCRIPTION
## Summary

This PR adds `displayName` support to user profiles and makes `username` immutable after account creation.

## What changed

- Added `displayName` to the Prisma `User` model and created a database migration.
- Updated `updateProfile` so users can change `displayName` and `bio`, but not `username`.
- Allowed `displayName` to be cleared by sending `null`.
- Updated profile validation to reject `username` in the update payload and validate `displayName` with the same rules as the existing username checks.
- Added `displayName` to the GraphQL `User` type.
- Kept cached user objects in sync through the existing sanitization flow, so `displayName` is preserved in user cache entries.

Closes issue #211
