### PR TITLE
Add account deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dev:imageDeletion-worker": "tsx src/workers/imageDeletion.worker.ts",
     "dev:moderationMetrics-worker": "tsx src/workers/moderationMetrics.worker.ts",
     "dev:deleteContent-worker": "tsx src/workers/deleteContent.worker.ts",
+    "dev:accountDeletion-worker": "tsx src/workers/accountDeletion.worker.ts",
     "dev:moderationAudit-worker": "tsx src/workers/moderationAudit.worker.ts",
     "dev:notification-worker": "tsx src/workers/notification.worker.ts",
     "dev:topicDetermination-worker": "tsx src/workers/topicDetermination.worker.ts",
@@ -35,7 +36,7 @@
     "dev:aiSuggestion-worker": "tsx src/workers/aiSuggestion.worker.ts",
     "dev:similarQuestions-worker": "tsx src/workers/similarQuestions.worker.ts",
     "dev:userInterest-worker": "tsx src/workers/userInterest.worker.ts",
-    "dev:all-workers": "concurrently \"npm run dev:email-worker\" \"npm run dev:contentModeration-worker\" \"npm run dev:questionVersioning-worker\" \"npm run dev:contentPipelineRouter-worker\" \"npm run dev:stats-worker\" \"npm run dev:imageModeration-worker\" \"npm run dev:contentFinalize-worker\" \"npm run dev:imageDeletion-worker\" \"npm run dev:moderationMetrics-worker\" \"npm run dev:deleteContent-worker\" \"npm run dev:moderationAudit-worker\" \"npm run dev:notification-worker\" \"npm run dev:topicDetermination-worker\" \"npm run dev:questionEmbedding-worker\" \"npm run dev:aiAnswer-worker\" \"npm run dev:aiSuggestion-worker\" \"npm run dev:similarQuestions-worker\" \"npm run dev:userInterest-worker\"",
+    "dev:all-workers": "concurrently \"npm run dev:email-worker\" \"npm run dev:contentModeration-worker\" \"npm run dev:questionVersioning-worker\" \"npm run dev:contentPipelineRouter-worker\" \"npm run dev:stats-worker\" \"npm run dev:imageModeration-worker\" \"npm run dev:contentFinalize-worker\" \"npm run dev:imageDeletion-worker\" \"npm run dev:moderationMetrics-worker\" \"npm run dev:deleteContent-worker\" \"npm run dev:accountDeletion-worker\" \"npm run dev:moderationAudit-worker\" \"npm run dev:notification-worker\" \"npm run dev:topicDetermination-worker\" \"npm run dev:questionEmbedding-worker\" \"npm run dev:aiAnswer-worker\" \"npm run dev:aiSuggestion-worker\" \"npm run dev:similarQuestions-worker\" \"npm run dev:userInterest-worker\"",
     "build": "tsc",
     "lint": "eslint src/**/*.{js,ts}",
     "format": "prettier --write 'src/**/*.{js,ts,json,md}'"

--- a/prisma/migrations/20260515172513_add_deleted_account_support_to_user_model/migration.sql
+++ b/prisma/migrations/20260515172513_add_deleted_account_support_to_user_model/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "tokenVersion" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/migrations/20260515194102_add_account_deletion_tracking/migration.sql
+++ b/prisma/migrations/20260515194102_add_account_deletion_tracking/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "accountDeletionCompletedAt" TIMESTAMP(3),
+ADD COLUMN     "accountDeletionRequestedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -190,10 +190,13 @@ model User {
   acceptedAnswers  Int           @default(0)
   bestAnswers      Int           @default(0)
   achievements     Achievement[]
-  status           Status        @default(ACTIVE)
 
   credits               Int       @default(20)
   creditsLastRedeemedAt DateTime?
+
+  status    Status    @default(ACTIVE)
+  isDeleted Boolean   @default(false)
+  deletedAt DateTime?
 
   moderationStrikes ModerationStrike[]
   warnings          Warning[]
@@ -212,6 +215,8 @@ model User {
   resetPasswordOtpExpireAt          DateTime?
   isVerified                        Boolean      @default(false)
   authProvider                      AuthProvider @default(LOCAL)
+
+  tokenVersion Int @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,9 +194,12 @@ model User {
   credits               Int       @default(20)
   creditsLastRedeemedAt DateTime?
 
-  status    Status    @default(ACTIVE)
-  isDeleted Boolean   @default(false)
-  deletedAt DateTime?
+  status Status @default(ACTIVE)
+
+  isDeleted                  Boolean   @default(false)
+  deletedAt                  DateTime?
+  accountDeletionRequestedAt DateTime?
+  accountDeletionCompletedAt DateTime?
 
   moderationStrikes ModerationStrike[]
   warnings          Warning[]

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -31,7 +31,9 @@ import emailQueue from "../queues/email.queue.js";
 const register = asyncHandler(async (req: Request, res: Response) => {
   const { username, email, password } = req.body;
 
-  const emailExists = await prisma.user.findUnique({ where: { email } });
+  const emailExists = await prisma.user.findFirst({
+    where: { email, isDeleted: false },
+  });
   if (emailExists) throw new HttpError("Email is already in use", 400);
 
   const usernameExists = await prisma.user.findUnique({ where: { username } });
@@ -61,7 +63,7 @@ const register = asyncHandler(async (req: Request, res: Response) => {
     return createdUser;
   });
 
-  generateToken(res, newUser.id);
+  generateToken(res, newUser.id, newUser.tokenVersion);
 
   const deviceInfo = getDeviceInfo(req);
   const deviceName = `${deviceInfo.browser} on ${deviceInfo.os}`;
@@ -106,7 +108,9 @@ const register = asyncHandler(async (req: Request, res: Response) => {
 const login = asyncHandler(async (req: Request, res: Response) => {
   const { email, password } = req.body;
 
-  const foundUser = await prisma.user.findUnique({ where: { email } });
+  const foundUser = await prisma.user.findFirst({
+    where: { email, isDeleted: false },
+  });
 
   if (!foundUser) throw new HttpError("Invalid credentials", 400);
 
@@ -115,7 +119,7 @@ const login = asyncHandler(async (req: Request, res: Response) => {
   const isPasswordCorrect = await bcrypt.compare(password, foundUser.password);
   if (!isPasswordCorrect) throw new HttpError("Invalid password", 401);
 
-  generateToken(res, foundUser.id);
+  generateToken(res, foundUser.id, foundUser.tokenVersion);
 
   await getRedisCacheClient().set(
     `user:${foundUser.id}`,
@@ -148,7 +152,9 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
     if (!email_verified)
       throw new HttpError("Email not verified, couldn't register", 400);
 
-    const foundUser = await prisma.user.findUnique({ where: { email } });
+    const foundUser = await prisma.user.findFirst({
+      where: { email, isDeleted: false },
+    });
 
     if (!foundUser) {
       const uniqueUsername = await generateOAuthUsername(name);
@@ -164,7 +170,7 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
           notificationSettings: { create: {} },
         },
       });
-      generateToken(res, newUser.id);
+      generateToken(res, newUser.id, newUser.tokenVersion);
 
       return res.status(200).json({
         message: "Successfully registered",
@@ -180,7 +186,7 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
           400,
         );
 
-      generateToken(res, foundUser.id);
+      generateToken(res, foundUser.id, foundUser.tokenVersion);
 
       return res.status(200).json({
         message: "Successfully logged in",
@@ -204,7 +210,9 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
     if (!email || !name)
       throw new HttpError("Invalid Github access token", 400);
 
-    const foundUser = await prisma.user.findUnique({ where: { email } });
+    const foundUser = await prisma.user.findFirst({
+      where: { email, isDeleted: false },
+    });
 
     if (!foundUser) {
       const uniqueUsername = await generateOAuthUsername(name);
@@ -221,7 +229,7 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
         },
       });
 
-      generateToken(res, newUser.id);
+      generateToken(res, newUser.id, newUser.tokenVersion);
 
       return res.status(200).json({
         message: "Successfully registered",
@@ -234,7 +242,7 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
           400,
         );
 
-      generateToken(res, foundUser.id);
+      generateToken(res, foundUser.id, foundUser.tokenVersion);
 
       return res.status(200).json({
         message: "Successfully logged in",
@@ -397,7 +405,9 @@ const sendResetPasswordEmail = asyncHandler(
   async (req: Request, res: Response) => {
     const { email } = req.body;
 
-    const foundUser = await prisma.user.findUnique({ where: { email } });
+    const foundUser = await prisma.user.findFirst({
+      where: { email, isDeleted: false },
+    });
 
     if (!foundUser || foundUser.authProvider !== "LOCAL") {
       return res
@@ -468,7 +478,9 @@ const resendResetPasswordEmail = asyncHandler(
   async (req: Request, res: Response) => {
     const { email } = req.body;
 
-    const foundUser = await prisma.user.findUnique({ where: { email } });
+    const foundUser = await prisma.user.findFirst({
+      where: { email, isDeleted: false },
+    });
 
     if (!foundUser) throw new HttpError("Invalid credentials", 404);
 
@@ -547,7 +559,9 @@ const verifyResetPasswordOtp = asyncHandler(
   async (req: Request, res: Response) => {
     const { email, otp } = req.body;
 
-    const foundUser = await prisma.user.findUnique({ where: { email } });
+    const foundUser = await prisma.user.findFirst({
+      where: { email, isDeleted: false },
+    });
 
     if (!foundUser) throw new HttpError("Invalid credentials", 404);
 
@@ -604,7 +618,9 @@ const verifyResetPasswordOtp = asyncHandler(
 const resetPassword = asyncHandler(async (req: Request, res: Response) => {
   const { email, newPassword } = req.body;
 
-  const foundUser = await prisma.user.findUnique({ where: { email } });
+    const foundUser = await prisma.user.findFirst({
+      where: { email, isDeleted: false },
+    });
 
   if (!foundUser) throw new HttpError("Invalid credentials", 404);
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -65,6 +65,13 @@ const register = asyncHandler(async (req: Request, res: Response) => {
 
   generateToken(res, newUser.id, newUser.tokenVersion);
 
+  await getRedisCacheClient().set(
+    `user:${newUser.id}`,
+    JSON.stringify(sanitizeUser(newUser)),
+    "EX",
+    60 * 20,
+  );
+
   const deviceInfo = getDeviceInfo(req);
   const deviceName = `${deviceInfo.browser} on ${deviceInfo.os}`;
   const htmlContent = verificationHtml(
@@ -120,7 +127,6 @@ const login = asyncHandler(async (req: Request, res: Response) => {
   if (!isPasswordCorrect) throw new HttpError("Invalid password", 401);
 
   generateToken(res, foundUser.id, foundUser.tokenVersion);
-
   await getRedisCacheClient().set(
     `user:${foundUser.id}`,
     JSON.stringify(sanitizeUser(foundUser)),
@@ -172,6 +178,13 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
       });
       generateToken(res, newUser.id, newUser.tokenVersion);
 
+      await getRedisCacheClient().set(
+        `user:${newUser.id}`,
+        JSON.stringify(sanitizeUser(newUser)),
+        "EX",
+        60 * 20,
+      );
+
       return res.status(200).json({
         message: "Successfully registered",
         user: {
@@ -187,6 +200,13 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
         );
 
       generateToken(res, foundUser.id, foundUser.tokenVersion);
+
+      await getRedisCacheClient().set(
+        `user:${foundUser.id}`,
+        JSON.stringify(sanitizeUser(foundUser)),
+        "EX",
+        60 * 20,
+      );
 
       return res.status(200).json({
         message: "Successfully logged in",
@@ -231,6 +251,13 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
 
       generateToken(res, newUser.id, newUser.tokenVersion);
 
+      await getRedisCacheClient().set(
+        `user:${newUser.id}`,
+        JSON.stringify(sanitizeUser(newUser)),
+        "EX",
+        60 * 20,
+      );
+
       return res.status(200).json({
         message: "Successfully registered",
         user: { username: newUser.username, email: newUser.email },
@@ -243,6 +270,13 @@ const registerOrLogin = asyncHandler(async (req: Request, res: Response) => {
         );
 
       generateToken(res, foundUser.id, foundUser.tokenVersion);
+
+      await getRedisCacheClient().set(
+        `user:${foundUser.id}`,
+        JSON.stringify(sanitizeUser(foundUser)),
+        "EX",
+        60 * 20,
+      );
 
       return res.status(200).json({
         message: "Successfully logged in",
@@ -312,6 +346,8 @@ const verifyEmail = asyncHandler(
       "EX",
       60 * 20,
     );
+    
+    await getRedisCacheClient().del(`auth:user:${verifiedUser.id}`);
 
     await getRedisCacheClient().del(
       `auth:verify-email:attempts:${foundUser.id}`,
@@ -661,7 +697,9 @@ const isAuth = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user.id;
 
-    const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
+    const cachedUser = await getRedisCacheClient().get(
+      `user:${userId}`,
+    );
     const foundUser = cachedUser
       ? JSON.parse(cachedUser)
       : await prisma.user.findUnique({ where: { id: userId } });

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -5,7 +5,7 @@ import asyncHandler from "../middlewares/asyncHandler.middleware.js";
 import AuthenticatedRequest from "../types/authenticatedRequest.type.js";
 
 import HttpError from "../utils/httpError.util.js";
-import interests from "../utils/interests.util.js";
+import buildDeletedUserData from "../utils/buildDeletedUserData.util.js";
 import sanitizeUser from "../utils/sanitizeUser.util.js";
 
 import { makeJobId } from "../utils/makeJobId.util.js";
@@ -13,6 +13,7 @@ import { makeJobId } from "../utils/makeJobId.util.js";
 import { clearNotificationCache } from "../utils/clearCache.util.js";
 
 import { getRedisCacheClient } from "../config/redis.config.js";
+import { getRedisPub } from "../redis/redis.pubsub.js";
 
 import mongoose from "mongoose";
 
@@ -22,6 +23,7 @@ import prisma from "../config/prisma.config.js";
 
 import imageModerationQueue from "../queues/imageModeration.queue.js";
 import imageDeletionQueue from "../queues/imageDeletion.queue.js";
+import accountDeletionQueue from "../queues/accountDeletion.queue.js";
 
 const updateProfilePicture = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
@@ -72,7 +74,9 @@ const deleteProfilePicture = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user.id;
 
-    const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
+    const cachedUser = await getRedisCacheClient().get(
+      `user:${userId}`,
+    );
     const foundUser = cachedUser
       ? JSON.parse(cachedUser)
       : await prisma.user.findUnique({
@@ -132,7 +136,9 @@ const updateProfile = asyncHandler(
     const userId = req.user.id;
     const { displayName, bio } = req.body;
 
-    const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
+    const cachedUser = await getRedisCacheClient().get(
+      `user:${userId}`,
+    );
     const foundUser = cachedUser
       ? JSON.parse(cachedUser)
       : await prisma.user.findUnique({ where: { id: userId } });
@@ -164,6 +170,67 @@ const updateProfile = asyncHandler(
     return res.status(200).json({
       message: "Successfully updated profile",
       user: sanitizeUser(updatedUser),
+    });
+  },
+);
+
+const deleteAccount = asyncHandler(
+  async (req: AuthenticatedRequest, res: Response) => {
+    const userId = req.user.id;
+
+    const foundUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        tokenVersion: true,
+        status: true,
+        isDeleted: true,
+        profilePictureKey: true,
+        deletedAt: true,
+      },
+    });
+
+    if (!foundUser) throw new HttpError("User not found", 404);
+
+    if (foundUser.isDeleted)
+      throw new HttpError("User already deleted", 409);
+
+    const deletedAt = foundUser.deletedAt ?? new Date();
+    const deletedUserData = buildDeletedUserData(userId, deletedAt);
+
+    const updatedUser = await prisma.user.update({
+      where: { id: userId },
+      data: {
+        ...deletedUserData,
+        tokenVersion: { increment: 1 },
+      },
+    });
+
+    await getRedisCacheClient().set(
+      `user:${userId}`,
+      JSON.stringify(sanitizeUser(updatedUser)),
+      "EX",
+      60 * 20,
+    );
+    await getRedisCacheClient().del(`auth:user:${userId}`);
+    await clearNotificationCache(userId);
+    await getRedisPub().publish("socket:disconnect", JSON.stringify(userId));
+
+    await accountDeletionQueue.add(
+      "DELETE_ACCOUNT",
+      {
+        userId,
+        profilePictureKey: foundUser.profilePictureKey,
+      },
+      {
+        removeOnComplete: true,
+        removeOnFail: false,
+        jobId: makeJobId("accountDeletion", "DELETE_ACCOUNT", userId),
+      },
+    );
+
+    return res.status(202).json({
+      message: "Account deletion queued",
     });
   },
 );
@@ -241,6 +308,7 @@ export {
   updateProfilePicture,
   deleteProfilePicture,
   updateProfile,
+  deleteAccount,
   getNotificationSettings,
   updateNotificationSettings,
   markNotificationsAsSeen,

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -185,6 +185,8 @@ const deleteAccount = asyncHandler(
         tokenVersion: true,
         status: true,
         isDeleted: true,
+        accountDeletionRequestedAt: true,
+        accountDeletionCompletedAt: true,
         profilePictureKey: true,
         deletedAt: true,
       },
@@ -192,19 +194,36 @@ const deleteAccount = asyncHandler(
 
     if (!foundUser) throw new HttpError("User not found", 404);
 
-    if (foundUser.isDeleted)
+    if (foundUser.isDeleted && foundUser.accountDeletionCompletedAt)
       throw new HttpError("User already deleted", 409);
 
     const deletedAt = foundUser.deletedAt ?? new Date();
-    const deletedUserData = buildDeletedUserData(userId, deletedAt);
+    const deletedUserData = await buildDeletedUserData(
+      userId,
+      deletedAt,
+      async (username) =>
+        !(await prisma.user.findUnique({
+          where: { username },
+          select: { id: true },
+        })),
+    );
 
-    const updatedUser = await prisma.user.update({
-      where: { id: userId },
-      data: {
-        ...deletedUserData,
-        tokenVersion: { increment: 1 },
-      },
-    });
+    const updatedUser = foundUser.isDeleted
+      ? await prisma.user.update({
+          where: { id: userId },
+          data: {
+            accountDeletionRequestedAt:
+              foundUser.accountDeletionRequestedAt ?? deletedAt,
+          },
+        })
+      : await prisma.user.update({
+          where: { id: userId },
+          data: {
+            ...deletedUserData,
+            accountDeletionRequestedAt: deletedAt,
+            tokenVersion: { increment: 1 },
+          },
+        });
 
     await getRedisCacheClient().set(
       `user:${userId}`,

--- a/src/dataloaders/user.loader.ts
+++ b/src/dataloaders/user.loader.ts
@@ -1,6 +1,7 @@
 import DataLoader from "dataloader";
 
 import prisma from "../config/prisma.config.js";
+import sanitizeUser from "../utils/sanitizeUser.util.js";
 
 const batchUsers = async (userIds: readonly string[]) => {
   const users = await prisma.user.findMany({
@@ -10,7 +11,7 @@ const batchUsers = async (userIds: readonly string[]) => {
   const userMap: Record<string, unknown> = {};
 
   users.forEach((user) => {
-    userMap[user.id] = user;
+    userMap[user.id] = sanitizeUser(user);
   });
 
   return userIds.map((id) => userMap[id]);

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -5,6 +5,7 @@ import asyncHandler from "./asyncHandler.middleware.js";
 import { NextFunction, Request, Response } from "express";
 
 import HttpError from "../utils/httpError.util.js";
+import sanitizeUserForAuth from "../utils/sanitizeUserForAuth.util.js";
 
 import prisma from "../config/prisma.config.js";
 
@@ -36,7 +37,7 @@ const isAuthenticated = asyncHandler(
     }
 
     const cachedUser = await getRedisCacheClient().get(
-      `user:${decoded.userId}`,
+      `auth:user:${decoded.userId}`,
     );
 
     const user = cachedUser
@@ -60,6 +61,15 @@ const isAuthenticated = asyncHandler(
 
     if (user.isDeleted || user.status !== "ACTIVE")
       throw new HttpError("User not active", 403);
+
+    if (!cachedUser) {
+      await getRedisCacheClient().set(
+        `auth:user:${user.id}`,
+        JSON.stringify(sanitizeUserForAuth(user)),
+        "EX",
+        60 * 20,
+      );
+    }
 
     req.user = user;
     next();

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -29,6 +29,7 @@ const isAuthenticated = asyncHandler(
     try {
       decoded = jwt.verify(token, process.env.JWT_SECRET as string) as {
         userId: string;
+        tokenVersion?: number;
       };
     } catch (error) {
       throw new HttpError("Not authenticated, token failed", 401);
@@ -42,10 +43,23 @@ const isAuthenticated = asyncHandler(
       ? JSON.parse(cachedUser)
       : await prisma.user.findUnique({
           where: { id: decoded.userId },
-          select: { id: true, status: true, isVerified: true, role: true },
+          select: {
+            id: true,
+            tokenVersion: true,
+            status: true,
+            isVerified: true,
+            role: true,
+            isDeleted: true,
+          },
         });
 
     if (!user) throw new HttpError("User not found", 404);
+
+    if (Number(user.tokenVersion ?? 0) !== Number(decoded.tokenVersion ?? 0))
+      throw new HttpError("User token expired", 401);
+
+    if (user.isDeleted || user.status !== "ACTIVE")
+      throw new HttpError("User not active", 403);
 
     req.user = user;
     next();
@@ -61,7 +75,7 @@ const isVerified = asyncHandler(
 
 const requireActiveUser = asyncHandler(
   async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    if (req.user?.status !== "ACTIVE")
+    if (req.user?.status !== "ACTIVE" || req.user?.isDeleted)
       throw new HttpError("User not active", 403);
 
     next();

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -59,7 +59,7 @@ const isAuthenticated = asyncHandler(
     if (Number(user.tokenVersion ?? 0) !== Number(decoded.tokenVersion ?? 0))
       throw new HttpError("User token expired", 401);
 
-    if (user.isDeleted || user.status !== "ACTIVE")
+    if (user.isDeleted)
       throw new HttpError("User not active", 403);
 
     if (!cachedUser) {
@@ -83,10 +83,10 @@ const isVerified = asyncHandler(
   },
 );
 
-const requireActiveUser = asyncHandler(
-  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    if (req.user?.status !== "ACTIVE" || req.user?.isDeleted)
-      throw new HttpError("User not active", 403);
+  const requireActiveUser = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+      if (req.user?.status !== "ACTIVE")
+        throw new HttpError("User not active", 403);
 
     next();
   },

--- a/src/middlewares/graphqlAuth.middleware.ts
+++ b/src/middlewares/graphqlAuth.middleware.ts
@@ -17,6 +17,7 @@ const authenticateGraphQLUser = async (req: AuthenticatedRequest) => {
   try {
     decoded = jwt.verify(token, process.env.JWT_SECRET as string) as {
       userId: string;
+      tokenVersion?: number;
     };
   } catch (err) {
     throw new HttpError("Not authenticated, token failed", 401);
@@ -32,13 +33,21 @@ const authenticateGraphQLUser = async (req: AuthenticatedRequest) => {
     if (!cachedUserObj.isVerified)
       throw new HttpError("User not verified", 403);
 
-    if (cachedUserObj.status !== "ACTIVE")
+    if (
+      Number(cachedUserObj.tokenVersion ?? 0) !==
+      Number(decoded.tokenVersion ?? 0)
+    )
+      throw new HttpError("User token expired", 401);
+
+    if (cachedUserObj.status !== "ACTIVE" || cachedUserObj.isDeleted)
       throw new HttpError("User not active", 403);
 
     return cachedUserObj;
   }
 
-  const foundUser = await prisma.user.findUnique({ where: { id: userId } });
+  const foundUser = await prisma.user.findUnique({
+    where: { id: userId },
+  });
   if (!foundUser) throw new HttpError("User not found", 404);
 
   await getRedisCacheClient().set(
@@ -49,7 +58,9 @@ const authenticateGraphQLUser = async (req: AuthenticatedRequest) => {
   );
 
   if (!foundUser.isVerified) throw new HttpError("User not verified", 403);
-  if (foundUser.status !== "ACTIVE")
+  if (Number(foundUser.tokenVersion ?? 0) !== Number(decoded.tokenVersion ?? 0))
+    throw new HttpError("User token expired", 401);
+  if (foundUser.status !== "ACTIVE" || foundUser.isDeleted)
     throw new HttpError("User not active", 403);
 
   return sanitizeUser(foundUser);

--- a/src/middlewares/graphqlAuth.middleware.ts
+++ b/src/middlewares/graphqlAuth.middleware.ts
@@ -1,7 +1,7 @@
 import jwt from "jsonwebtoken";
 
 import HttpError from "../utils/httpError.util.js";
-import sanitizeUser from "../utils/sanitizeUser.util.js";
+import sanitizeUserForAuth from "../utils/sanitizeUserForAuth.util.js";
 
 import prisma from "../config/prisma.config.js";
 import { getRedisCacheClient } from "../config/redis.config.js";
@@ -25,7 +25,7 @@ const authenticateGraphQLUser = async (req: AuthenticatedRequest) => {
 
   const userId = decoded.userId;
 
-  const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
+  const cachedUser = await getRedisCacheClient().get(`auth:user:${userId}`);
 
   if (cachedUser) {
     const cachedUserObj = JSON.parse(cachedUser);
@@ -47,12 +47,20 @@ const authenticateGraphQLUser = async (req: AuthenticatedRequest) => {
 
   const foundUser = await prisma.user.findUnique({
     where: { id: userId },
+    select: {
+      id: true,
+      tokenVersion: true,
+      status: true,
+      isVerified: true,
+      role: true,
+      isDeleted: true,
+    },
   });
   if (!foundUser) throw new HttpError("User not found", 404);
 
   await getRedisCacheClient().set(
-    `user:${userId}`,
-    JSON.stringify(sanitizeUser(foundUser)),
+    `auth:user:${userId}`,
+    JSON.stringify(sanitizeUserForAuth(foundUser)),
     "EX",
     60 * 20,
   );
@@ -63,7 +71,7 @@ const authenticateGraphQLUser = async (req: AuthenticatedRequest) => {
   if (foundUser.status !== "ACTIVE" || foundUser.isDeleted)
     throw new HttpError("User not active", 403);
 
-  return sanitizeUser(foundUser);
+  return sanitizeUserForAuth(foundUser);
 };
 
 export default authenticateGraphQLUser;

--- a/src/queues/accountDeletion.queue.ts
+++ b/src/queues/accountDeletion.queue.ts
@@ -1,0 +1,9 @@
+import { Queue } from "bullmq";
+
+import { redisMessagingClientConnection } from "../config/redis.config.js";
+
+const accountDeletionQueue = new Queue("accountDeletionQueue", {
+  connection: redisMessagingClientConnection,
+});
+
+export default accountDeletionQueue;

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -2,6 +2,7 @@ import express from "express";
 
 import {
   deleteProfilePicture,
+  deleteAccount,
   updateProfile,
   updateProfilePicture,
   getNotificationSettings,
@@ -43,6 +44,10 @@ router
 router
   .route("/profile/picture")
   .delete(isAuthenticated, isVerified, requireActiveUser, deleteProfilePicture);
+
+router
+  .route("/account")
+  .delete(isAuthenticated, isVerified, deleteAccount);
 
 router
   .route("/update/profile")

--- a/src/services/socket/decodeSocketToken.service.ts
+++ b/src/services/socket/decodeSocketToken.service.ts
@@ -3,13 +3,17 @@ import jwt from "jsonwebtoken";
 const decodeSocketToken = (token: string) => {
   const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as {
     userId?: string;
+    tokenVersion?: number;
   };
 
   if (!decoded.userId) {
     throw new Error("Authentication failed");
   }
 
-  return decoded.userId;
+  return {
+    userId: decoded.userId,
+    tokenVersion: decoded.tokenVersion ?? 0,
+  };
 };
 
 export default decodeSocketToken;

--- a/src/services/socket/validateSocketUser.service.ts
+++ b/src/services/socket/validateSocketUser.service.ts
@@ -3,25 +3,37 @@ import { getRedisCacheClient } from "../../config/redis.config.js";
 
 type SocketConnectUser = {
   id: string;
+  tokenVersion: number;
   status: string;
   isVerified: boolean;
+  isDeleted?: boolean;
 };
 
-const validateSocketUser = async (userId: string) => {
+const validateSocketUser = async (userId: string, tokenVersion: number) => {
   const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
 
   const user: SocketConnectUser | null = cachedUser
     ? (JSON.parse(cachedUser) as SocketConnectUser)
     : await prisma.user.findUnique({
         where: { id: userId },
-        select: { id: true, status: true, isVerified: true },
+        select: {
+          id: true,
+          tokenVersion: true,
+          status: true,
+          isVerified: true,
+          isDeleted: true,
+        },
       });
 
   if (!user) {
     throw new Error("User not found");
   }
 
-  if (!user.isVerified || user.status !== "ACTIVE") {
+  if (Number(user.tokenVersion ?? 0) !== Number(tokenVersion ?? 0)) {
+    throw new Error("User token expired");
+  }
+
+  if (!user.isVerified || user.status !== "ACTIVE" || user.isDeleted) {
     throw new Error("Unauthorized user");
   }
 };

--- a/src/services/socket/validateSocketUser.service.ts
+++ b/src/services/socket/validateSocketUser.service.ts
@@ -10,7 +10,7 @@ type SocketConnectUser = {
 };
 
 const validateSocketUser = async (userId: string, tokenVersion: number) => {
-  const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
+  const cachedUser = await getRedisCacheClient().get(`auth:user:${userId}`);
 
   const user: SocketConnectUser | null = cachedUser
     ? (JSON.parse(cachedUser) as SocketConnectUser)

--- a/src/services/user/deleteAccount.service.ts
+++ b/src/services/user/deleteAccount.service.ts
@@ -1,0 +1,78 @@
+import prisma from "../../config/prisma.config.js";
+
+import Notification from "../../models/notification.model.js";
+import UserInterest from "../../models/userInterest.model.js";
+
+import { getRedisCacheClient } from "../../config/redis.config.js";
+
+import deleteSingleImageService from "../media/deleteSingleImage.service.js";
+
+import buildDeletedUserData from "../../utils/buildDeletedUserData.util.js";
+
+import { clearNotificationCache } from "../../utils/clearCache.util.js";
+
+type DeleteAccountJobData = {
+  userId: string;
+  profilePictureKey?: string | null;
+};
+
+const purgeAccountData = async ({
+  userId,
+  profilePictureKey,
+}: DeleteAccountJobData) => {
+  if (profilePictureKey) {
+    await deleteSingleImageService({ objectKey: profilePictureKey });
+  }
+
+  await Promise.all([
+    prisma.achievement.deleteMany({ where: { userId } }),
+    prisma.moderationStrike.deleteMany({ where: { userId } }),
+    prisma.warning.deleteMany({ where: { userId } }),
+    prisma.ban.deleteMany({ where: { userId } }),
+    prisma.moderationStats.deleteMany({ where: { userId } }),
+    prisma.notificationSettings.deleteMany({ where: { userId } }),
+  ]);
+
+  await Notification.deleteMany({
+    recipientId: userId,
+  });
+
+  await UserInterest.deleteMany({ userId });
+
+  await getRedisCacheClient().del(`user:${userId}`);
+  await clearNotificationCache(userId);
+};
+
+const softDeleteAccount = async (userId: string) => {
+  const foundUser = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      status: true,
+      isDeleted: true,
+      deletedAt: true,
+    },
+  });
+
+  if (!foundUser) return null;
+
+  const deletedAt = foundUser.deletedAt ?? new Date();
+  const deletedUserData = buildDeletedUserData(userId, deletedAt);
+
+  const updatedUser = await prisma.user.update({
+    where: { id: userId },
+    data: deletedUserData,
+  });
+
+  return updatedUser;
+};
+
+const deleteAccount = async (jobData: DeleteAccountJobData) => {
+  const { userId } = jobData;
+
+  await purgeAccountData(jobData);
+  await softDeleteAccount(userId);
+};
+
+export default deleteAccount;
+export { purgeAccountData, softDeleteAccount };

--- a/src/services/user/deleteAccount.service.ts
+++ b/src/services/user/deleteAccount.service.ts
@@ -51,17 +51,31 @@ const softDeleteAccount = async (userId: string) => {
       status: true,
       isDeleted: true,
       deletedAt: true,
+      accountDeletionCompletedAt: true,
     },
   });
 
   if (!foundUser) return null;
 
+  if (foundUser.accountDeletionCompletedAt) return foundUser;
+
   const deletedAt = foundUser.deletedAt ?? new Date();
-  const deletedUserData = buildDeletedUserData(userId, deletedAt);
+  const deletedUserData = await buildDeletedUserData(
+    userId,
+    deletedAt,
+    async (username) =>
+      !(await prisma.user.findUnique({
+        where: { username },
+        select: { id: true },
+      })),
+  );
 
   const updatedUser = await prisma.user.update({
     where: { id: userId },
-    data: deletedUserData,
+    data: {
+      ...deletedUserData,
+      accountDeletionCompletedAt: new Date(),
+    },
   });
 
   return updatedUser;

--- a/src/sockets/index.ts
+++ b/src/sockets/index.ts
@@ -36,8 +36,8 @@ const initSocket = (server: http.Server) => {
 
       if (!token) return next(new Error("Not authenticated: no token"));
 
-      const userId = decodeSocketToken(token);
-      await validateSocketUser(userId);
+      const { userId, tokenVersion } = decodeSocketToken(token);
+      await validateSocketUser(userId, tokenVersion);
 
       socket.data.userId = userId;
 

--- a/src/utils/buildDeletedUserData.util.ts
+++ b/src/utils/buildDeletedUserData.util.ts
@@ -1,6 +1,30 @@
-const buildDeletedUserData = (userId: string, deletedAt = new Date()) => {
+type UsernameAvailabilityChecker = (username: string) => Promise<boolean>;
+
+const buildDeletedUserData = async (
+  userId: string,
+  deletedAt = new Date(),
+  isUsernameAvailable?: UsernameAvailabilityChecker,
+) => {
   const suffix = userId.replace(/-/g, "").slice(0, 8).toLowerCase();
-  const username = `deleted_${suffix}`;
+  const baseUsername = `deleted_${suffix}`;
+  let username = baseUsername;
+
+  if (isUsernameAvailable) {
+    let resolved = false;
+    for (let i = 0; i < 50; i++) {
+      const candidate = i === 0 ? baseUsername : `${baseUsername}_${i}`;
+      if (await isUsernameAvailable(candidate)) {
+        username = candidate;
+        resolved = true;
+        break;
+      }
+    }
+
+    if (!resolved) {
+      throw new Error("Unable to reserve a deleted username");
+    }
+  }
+
   const email = `${username}@deleted.local`;
 
   return {

--- a/src/utils/buildDeletedUserData.util.ts
+++ b/src/utils/buildDeletedUserData.util.ts
@@ -1,0 +1,37 @@
+const buildDeletedUserData = (userId: string, deletedAt = new Date()) => {
+  const suffix = userId.replace(/-/g, "").slice(0, 8).toLowerCase();
+  const username = `deleted_${suffix}`;
+  const email = `${username}@deleted.local`;
+
+  return {
+    username,
+    displayName: "Deleted User",
+    email,
+    password: null,
+    profilePictureUrl: null,
+    profilePictureKey: null,
+    bio: null,
+    reputationPoints: 0,
+    role: "USER" as const,
+    questionsAsked: 0,
+    answersGiven: 0,
+    acceptedAnswers: 0,
+    bestAnswers: 0,
+    status: "TERMINATED" as const,
+    credits: 0,
+    creditsLastRedeemedAt: null,
+    otp: null,
+    otpResendAvailableAt: null,
+    otpExpireAt: null,
+    resetPasswordOtp: null,
+    resetPasswordOtpVerified: null,
+    resetPasswordOtpResendAvailableAt: null,
+    resetPasswordOtpExpireAt: null,
+    isVerified: false,
+    authProvider: "LOCAL" as const,
+    isDeleted: true,
+    deletedAt,
+  };
+};
+
+export default buildDeletedUserData;

--- a/src/utils/generateToken.util.ts
+++ b/src/utils/generateToken.util.ts
@@ -1,10 +1,14 @@
 import { Response } from "express";
 import jwt from "jsonwebtoken";
 
-const generateToken = (res: Response, userId: string) => {
-  const token = jwt.sign({ userId }, process.env.JWT_SECRET as string, {
-    expiresIn: "7d",
-  });
+const generateToken = (res: Response, userId: string, tokenVersion: number) => {
+  const token = jwt.sign(
+    { userId, tokenVersion },
+    process.env.JWT_SECRET as string,
+    {
+      expiresIn: "7d",
+    },
+  );
 
   res.cookie("token", token, {
     httpOnly: true,

--- a/src/utils/sanitizeUser.util.ts
+++ b/src/utils/sanitizeUser.util.ts
@@ -12,6 +12,9 @@ const sanitizeUser = (user: User) => {
     resetPasswordOtpResendAvailableAt,
     resetPasswordOtpExpireAt,
     creditsLastRedeemedAt,
+    deletedAt,
+    accountDeletionRequestedAt,
+    accountDeletionCompletedAt,
     ...userWithoutSensitiveInfo
   } = user;
 

--- a/src/utils/sanitizeUser.util.ts
+++ b/src/utils/sanitizeUser.util.ts
@@ -3,6 +3,7 @@ import { User } from "../generated/prisma/index.js";
 const sanitizeUser = (user: User) => {
   const {
     password,
+    tokenVersion,
     otp,
     otpResendAvailableAt,
     otpExpireAt,

--- a/src/utils/sanitizeUserForAuth.util.ts
+++ b/src/utils/sanitizeUserForAuth.util.ts
@@ -1,0 +1,10 @@
+const sanitizeUserForAuth = (user: any) => ({
+  id: user.id,
+  tokenVersion: user.tokenVersion ?? 0,
+  status: user.status,
+  isVerified: user.isVerified,
+  role: user.role,
+  isDeleted: user.isDeleted ?? false,
+});
+
+export default sanitizeUserForAuth;

--- a/src/validations/auth.schema.ts
+++ b/src/validations/auth.schema.ts
@@ -6,6 +6,17 @@ const require = createRequire(import.meta.url);
 const leoProfanity = require("leo-profanity");
 
 const normalize = (text: string) => text.replace(/[^a-zA-Z]+/g, " ");
+const isDeletedEmail = (email: string) =>
+  email.toLowerCase().endsWith("@deleted.local");
+
+const activeEmailSchema = z
+  .string()
+  .email("Invalid email address")
+  .min(5, "Email must be at least 5 characters")
+  .max(345, "Email must be at most 345 characters")
+  .refine((email) => !isDeletedEmail(email), {
+    message: "This email address is reserved",
+  });
 
 const registerSchema = z.object({
   username: z
@@ -22,11 +33,7 @@ const registerSchema = z.object({
     .refine((username) => !leoProfanity.check(normalize(username)), {
       message: "Username contains inappropriate language",
     }),
-  email: z
-    .string()
-    .email("Invalid email address")
-    .min(5, "Email must be at least 5 characters")
-    .max(345, "Email must be at most 345 characters"),
+  email: activeEmailSchema,
   password: z
     .string()
     .min(8, "Password must be at least 8 characters")
@@ -40,11 +47,7 @@ const registerSchema = z.object({
 });
 
 const loginSchema = z.object({
-  email: z
-    .string()
-    .email("Invalid email address")
-    .min(5, "Email must be at least 5 characters")
-    .max(345, "Email must be at most 345 characters"),
+  email: activeEmailSchema,
   password: z
     .string()
     .min(8, "Password must be at least 8 characters")
@@ -75,19 +78,11 @@ const verifyEmailSchema = z.object({
 });
 
 const sendResetPasswordEmailSchema = z.object({
-  email: z
-    .string()
-    .email("Invalid email address")
-    .min(5, "Email must be at least 5 characters")
-    .max(345, "Email must be at most 345 characters"),
+  email: activeEmailSchema,
 });
 
 const verifyResetPasswordOtpSchema = z.object({
-  email: z
-    .string()
-    .email("Invalid email address")
-    .min(5, "Email must be at least 5 characters")
-    .max(345, "Email must be at most 345 characters"),
+  email: activeEmailSchema,
   otp: z
     .string()
     .max(6, "OTP should be exactly 6 characters")
@@ -95,11 +90,7 @@ const verifyResetPasswordOtpSchema = z.object({
 });
 
 const resetPasswordSchema = z.object({
-  email: z
-    .string()
-    .email("Invalid email address")
-    .min(5, "Email must be at least 5 characters")
-    .max(345, "Email must be at most 345 characters"),
+  email: activeEmailSchema,
   newPassword: z
     .string()
     .min(8, "Password must be at least 8 characters")

--- a/src/workers/accountDeletion.worker.ts
+++ b/src/workers/accountDeletion.worker.ts
@@ -1,0 +1,40 @@
+import { Worker } from "bullmq";
+
+import { redisMessagingClientConnection } from "../config/redis.config.js";
+import connectMongoDB from "../config/mongodb.config.js";
+
+import deleteAccount from "../services/user/deleteAccount.service.js";
+
+async function startWorker() {
+  await connectMongoDB(process.env.MONGO_URI as string);
+  console.log("Mongo connected, starting account deletion worker...");
+
+  const worker = new Worker(
+    "accountDeletionQueue",
+    async (job) => {
+      await deleteAccount(job.data as { userId: string; profilePictureKey?: string | null });
+    },
+    {
+      connection: redisMessagingClientConnection,
+      concurrency: 1,
+      limiter: { max: 5, duration: 5000 },
+    },
+  );
+
+  worker.on("completed", (job) => {
+    console.log(`Job ${job.id} completed`);
+  });
+
+  worker.on("failed", (job, err) => {
+    console.error(`Job ${job?.id} failed:`, err);
+  });
+
+  worker.on("error", (err) => {
+    console.error("Worker crashed:", err);
+  });
+}
+
+startWorker().catch((error) => {
+  console.error("Failed to start account deletion worker:", error);
+  process.exit(1);
+});

--- a/src/workers/notification.worker.ts
+++ b/src/workers/notification.worker.ts
@@ -42,8 +42,10 @@ async function startWorker() {
               select: {
                 id: true,
                 username: true,
+                displayName: true,
                 profilePictureKey: true,
                 profilePictureUrl: true,
+                isDeleted: true,
               },
             });
           }


### PR DESCRIPTION
## Overview
This branch adds a background-queued self-service account deletion flow and introduces `tokenVersion`-based JWT revocation for logout-all behavior. It also separates public user cache data from auth-only cache data so internal auth state does not leak through general user reads.

## What Changed

### Account Deletion
- Added `DELETE /api/user/account`.
- The route now:
  - verifies the requesting user
  - tombstones the account immediately
  - increments `tokenVersion`
  - clears the auth cookie for the current browser
  - clears notification cache
  - disconnects active sockets for the deleted account
  - enqueues the heavy cleanup work to a background worker

### Background Cleanup
- Added a dedicated account deletion queue/worker.
- The worker handles deferred cleanup tasks such as:
  - removing moderation and notification data tied to the deleted account
  - preserving content authored by the user
  - finalizing account removal without blocking the request cycle

### JWT Logout-All
- Added `tokenVersion` to the `User` model.
- JWTs now carry `tokenVersion`.
- Auth middleware compares the JWT version against the current user version.
- Any previously issued JWT becomes invalid after account deletion or other explicit invalidation events.

### Cache Split
- Split user cache usage into two logical shapes:
  - public user cache for normal reads
  - auth-only user cache for middleware/session validation
- Public controller flows now use public user serialization only.
- Auth middleware and socket validation use auth-only user data.

### Auth Policy Adjustments
- Deleted users remain blocked across auth paths.
- Banned users are handled differently by surface:
  - REST auth can still allow access to fetch ban state
  - GraphQL access is blocked for banned users
  - socket connections are blocked for banned users
- `DELETE /account` does not require `ACTIVE`, so banned users can still delete their account.

## Behavior After This Branch
- Current browser logout happens immediately via cookie clear.
- Other devices lose access on the next request because their JWT version no longer matches.
- Account deletion does not block the request while cleanup runs.
- Auth state is kept separate from public cached user data.

## Verification
- TypeScript build passes successfully.
- Main auth, GraphQL auth, and socket auth paths were updated to reflect the new policy split.

## Notes
- This branch intentionally keeps ban state visible to the user in REST while preventing banned users from using GraphQL or sockets.
- Self-delete is the explicit hard-revocation path; bans do not revoke JWTs.

closes #212 