### PR TITLE
Add Auth Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@types/node": "^24.3.0",
         "@types/nodemailer": "^7.0.1",
         "@types/sharp": "^0.31.1",
+        "@types/supertest": "^7.2.0",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
         "@typescript-eslint/parser": "^8.41.0",
@@ -67,9 +68,11 @@
         "mjml": "^4.15.3",
         "nodemon": "^3.1.10",
         "prettier": "^3.6.2",
+        "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -2798,10 +2801,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4071,6 +4075,38 @@
         "win32"
       ]
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4115,6 +4151,26 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4281,6 +4337,270 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.8",
@@ -5021,9 +5341,9 @@
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
@@ -5054,6 +5374,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/bcrypt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -5073,6 +5404,17 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/connect": {
@@ -5095,6 +5437,13 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -5103,6 +5452,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -5177,6 +5533,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -5306,6 +5669,30 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/uuid": {
@@ -5592,6 +5979,92 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@whatwg-node/promise-helpers": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
@@ -5761,6 +6234,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -5769,6 +6259,13 @@
       "dependencies": {
         "retry": "0.13.1"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -6105,6 +6602,16 @@
         "upper-case": "^1.1.1"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6351,12 +6858,35 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -6475,6 +7005,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -6501,6 +7038,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -6662,6 +7206,16 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -6701,6 +7255,17 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -7057,6 +7622,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7064,6 +7636,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7395,6 +7983,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7412,6 +8010,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -7542,6 +8150,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7708,6 +8323,46 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -7718,6 +8373,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -8675,6 +9348,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8806,6 +9740,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -8864,6 +9808,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
@@ -9688,6 +10642,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9940,6 +10913,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -10172,6 +11156,13 @@
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -10203,6 +11194,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -10324,9 +11344,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -10519,6 +11539,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
     "node_modules/router": {
@@ -10851,6 +11905,13 @@
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -11061,6 +12122,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -11069,6 +12140,13 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
@@ -11084,6 +12162,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -11223,6 +12308,52 @@
       ],
       "license": "MIT"
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -11252,6 +12383,13 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -11259,6 +12397,65 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-buffer": {
@@ -11403,6 +12600,7 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -11574,6 +12772,657 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/voyageai": {
@@ -11796,6 +13645,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/node": "^24.3.0",
     "@types/nodemailer": "^7.0.1",
     "@types/sharp": "^0.31.1",
+    "@types/supertest": "^7.2.0",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.41.0",
     "@typescript-eslint/parser": "^8.41.0",
@@ -101,8 +102,10 @@
     "mjml": "^4.15.3",
     "nodemon": "^3.1.10",
     "prettier": "^3.6.2",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.7"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,52 @@
+import express from "express";
+import cookieParser from "cookie-parser";
+
+type CreateAppOptions = {
+  includeAuthRoutes?: boolean;
+  includeUserRoutes?: boolean;
+  includeQuestionRoutes?: boolean;
+  includeModerationRoutes?: boolean;
+};
+
+const createApp = async ({
+  includeAuthRoutes = true,
+  includeUserRoutes = true,
+  includeQuestionRoutes = true,
+  includeModerationRoutes = true,
+}: CreateAppOptions = {}) => {
+  const app = express();
+
+  app.set("trust proxy", 1);
+
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+  app.use(cookieParser());
+
+  if (includeAuthRoutes) {
+    const { default: authRoute } = await import("./routes/auth.route.js");
+    app.use("/api/auth", authRoute);
+  }
+
+  if (includeUserRoutes) {
+    const { default: userRoute } = await import("./routes/user.route.js");
+    app.use("/api/user", userRoute);
+  }
+
+  if (includeQuestionRoutes) {
+    const { default: questionRoute } = await import(
+      "./routes/question.route.js"
+    );
+    app.use("/api/question", questionRoute);
+  }
+
+  if (includeModerationRoutes) {
+    const { default: moderationRoute } = await import(
+      "./routes/moderation.route.js"
+    );
+    app.use("/api/moderation", moderationRoute);
+  }
+
+  return app;
+};
+
+export default createApp;

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -74,9 +74,7 @@ const deleteProfilePicture = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.user.id;
 
-    const cachedUser = await getRedisCacheClient().get(
-      `user:${userId}`,
-    );
+    const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
     const foundUser = cachedUser
       ? JSON.parse(cachedUser)
       : await prisma.user.findUnique({
@@ -136,9 +134,7 @@ const updateProfile = asyncHandler(
     const userId = req.user.id;
     const { displayName, bio } = req.body;
 
-    const cachedUser = await getRedisCacheClient().get(
-      `user:${userId}`,
-    );
+    const cachedUser = await getRedisCacheClient().get(`user:${userId}`);
     const foundUser = cachedUser
       ? JSON.parse(cachedUser)
       : await prisma.user.findUnique({ where: { id: userId } });

--- a/src/graphql/typeDefs/moderation.typeDefs.ts
+++ b/src/graphql/typeDefs/moderation.typeDefs.ts
@@ -146,7 +146,7 @@ const moderationTypeDefs = gql`
       limitCount: Int
       showReviewed: Boolean
     ): ReportConnection!
-    
+
     strikes(
       filter: StrikeFilter
       cursor: StrikeCursorInput

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,27 @@
 import dotenv from "dotenv";
-import path from "path";
-import http from "http";
 import cors from "cors";
-
-import express from "express";
-
-import initSocket from "./sockets/index.js";
+import bodyParser from "body-parser";
+import http from "http";
+import path from "path";
 
 import { ApolloServer } from "@apollo/server";
 import { expressMiddleware } from "@as-integrations/express5";
-import bodyParser from "body-parser";
 
-import authenticateGraphQLUser from "./middlewares/graphqlAuth.middleware.js";
+import { User } from "./generated/prisma/index.js";
+import AuthenticatedRequest from "./types/authenticatedRequest.type.js";
 
-import createUserLoader from "./dataloaders/user.loader.js";
+import prisma from "./config/prisma.config.js";
+import connectMongoDB from "./config/mongodb.config.js";
+import { getRedisCacheClient } from "./config/redis.config.js";
+
+import closeAllRedisConnections from "./utils/closeAllRedisConnections.util.js";
 
 import typeDefs from "./graphql/typeDefs/index.js";
 import resolvers from "./graphql/resolvers/index.js";
-
-import authRoute from "./routes/auth.route.js";
-import userRoute from "./routes/user.route.js";
-import questionRoute from "./routes/question.route.js";
-import moderationRoute from "./routes/moderation.route.js";
-
-import cookieParser from "cookie-parser";
-
-import prisma from "./config/prisma.config.js";
-
-import { User } from "./generated/prisma/index.js";
-
-import AuthenticatedRequest from "./types/authenticatedRequest.type.js";
-
-import connectMongoDB from "./config/mongodb.config.js";
-
-import { getRedisCacheClient } from "./config/redis.config.js";
-import closeAllRedisConnections from "./utils/closeAllRedisConnections.util.js";
+import createUserLoader from "./dataloaders/user.loader.js";
+import authenticateGraphQLUser from "./middlewares/graphqlAuth.middleware.js";
+import initSocket from "./sockets/index.js";
+import createApp from "./app.js";
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env") });
 
@@ -45,25 +32,12 @@ const apolloServer = new ApolloServer({
 
 await apolloServer.start();
 
-const app = express();
+const app = await createApp();
 const server = http.createServer(app);
 
 initSocket(server);
 
 connectMongoDB(process.env.MONGO_URI as string);
-
-const port = Number(process.env.PORT) || 5000;
-
-app.set("trust proxy", 1);
-
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-app.use(cookieParser());
-
-app.use("/api/auth", authRoute);
-app.use("/api/user", userRoute);
-app.use("/api/question", questionRoute);
-app.use("/api/moderation", moderationRoute);
 
 app.use(
   "/graphql",
@@ -89,6 +63,8 @@ app.use(
     },
   }),
 );
+
+const port = Number(process.env.PORT) || 5000;
 
 server.on("error", (err) => {
   console.error("Server failed to start:", err);

--- a/src/middlewares/rate-limiters/auth.rate-limiters.ts
+++ b/src/middlewares/rate-limiters/auth.rate-limiters.ts
@@ -109,19 +109,28 @@ const passwordResetLimiterMiddleware = createRateLimiterMiddleware(
 const userEmailVerificationLimiterMiddleware = createRateLimiterMiddleware(
   userEmailVerificationLimiter,
   "Too many email verification requests from this account, please try again later",
-  (req) => (req as Request & { user?: { id?: string } }).user?.id || req.ip || "unknown",
+  (req) =>
+    (req as Request & { user?: { id?: string } }).user?.id ||
+    req.ip ||
+    "unknown",
 );
 
 const userResendEmailLimiterMiddleware = createRateLimiterMiddleware(
   userResendEmailLimiter,
   "Too many email resend requests from this account, please wait before requesting again",
-  (req) => (req as Request & { user?: { id?: string } }).user?.id || req.ip || "unknown",
+  (req) =>
+    (req as Request & { user?: { id?: string } }).user?.id ||
+    req.ip ||
+    "unknown",
 );
 
 const userPasswordChangeLimiterMiddleware = createRateLimiterMiddleware(
   userPasswordChangeLimiter,
   "Too many password change attempts from this account, please try again after an hour",
-  (req) => (req as Request & { user?: { id?: string } }).user?.id || req.ip || "unknown",
+  (req) =>
+    (req as Request & { user?: { id?: string } }).user?.id ||
+    req.ip ||
+    "unknown",
 );
 
 const sessionLimiterMiddleware = createRateLimiterMiddleware(

--- a/src/models/answer.model.ts
+++ b/src/models/answer.model.ts
@@ -37,7 +37,7 @@ const AnswerSchema: Schema = new Schema(
       versionKey: false,
       transform: (_, ret: any) => {
         ret.id = ret._id;
-        
+
         delete ret._id;
 
         return ret;

--- a/src/models/question.model.ts
+++ b/src/models/question.model.ts
@@ -24,7 +24,7 @@ const QuestionSchema: Schema = new Schema(
     similarQuestionsStatus: {
       type: String,
       enum: ["NONE", "PENDING", "PROCESSING", "READY"],
-      default: "NONE"
+      default: "NONE",
     },
 
     embedding: { type: [Number], default: null, required: false },
@@ -57,7 +57,7 @@ const QuestionSchema: Schema = new Schema(
       versionKey: false,
       transform: (_, ret: any) => {
         ret.id = ret._id;
-        
+
         delete ret._id;
 
         return ret;

--- a/src/models/questionVersion.model.ts
+++ b/src/models/questionVersion.model.ts
@@ -39,7 +39,7 @@ const QuestionVersionSchema: Schema = new Schema(
         ret.id = ret._id;
 
         delete ret._id;
-        
+
         return ret;
       },
     },

--- a/src/models/reply.model.ts
+++ b/src/models/reply.model.ts
@@ -27,7 +27,7 @@ const ReplySchema: Schema = new Schema(
       versionKey: false,
       transform: (_, ret: any) => {
         ret.id = ret._id;
-        
+
         delete ret._id;
 
         return ret;

--- a/src/models/report.model.ts
+++ b/src/models/report.model.ts
@@ -56,7 +56,7 @@ const ReportSchema: Schema = new Schema(
         ret.id = ret._id;
 
         delete ret._id;
-        
+
         return ret;
       },
     },

--- a/src/models/vote.model.ts
+++ b/src/models/vote.model.ts
@@ -20,7 +20,7 @@ const VoteSchema = new Schema(
         ret.id = ret._id;
 
         delete ret._id;
-        
+
         return ret;
       },
     },

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -45,9 +45,7 @@ router
   .route("/profile/picture")
   .delete(isAuthenticated, isVerified, requireActiveUser, deleteProfilePicture);
 
-router
-  .route("/account")
-  .delete(isAuthenticated, isVerified, deleteAccount);
+router.route("/account").delete(isAuthenticated, isVerified, deleteAccount);
 
 router
   .route("/update/profile")

--- a/src/services/auth/changePassword.service.ts
+++ b/src/services/auth/changePassword.service.ts
@@ -5,7 +5,11 @@ import publishSocketDisconnect from "../../utils/publishSocketDisconnect.util.js
 
 import prisma from "../../config/prisma.config.js";
 
-import { cacheAuthUser, cacheUser, removeResetPasswordAttempts } from "./auth.shared.js";
+import {
+  cacheAuthUser,
+  cacheUser,
+  removeResetPasswordAttempts,
+} from "./auth.shared.js";
 
 type ChangePasswordInput = {
   userId: string;
@@ -44,7 +48,10 @@ const changePassword = async ({
 
   const isSamePassword = await bcrypt.compare(newPassword, foundUser.password);
   if (isSamePassword)
-    throw new HttpError("New password must be different from the old password", 400);
+    throw new HttpError(
+      "New password must be different from the old password",
+      400,
+    );
 
   const hashedPassword = await bcrypt.hash(newPassword, 10);
 

--- a/src/services/auth/login.service.ts
+++ b/src/services/auth/login.service.ts
@@ -20,7 +20,10 @@ const login = async ({ email, password }: LoginInput) => {
   if (!foundUser.password) throw new HttpError("Invalid credentials", 400);
 
   if (await handleExpiredUnverifiedUser(foundUser)) {
-    throw new HttpError("Email verification expired, please sign up again", 410);
+    throw new HttpError(
+      "Email verification expired, please sign up again",
+      410,
+    );
   }
 
   const isPasswordCorrect = await bcrypt.compare(password, foundUser.password);

--- a/src/services/auth/register.service.ts
+++ b/src/services/auth/register.service.ts
@@ -23,7 +23,12 @@ type RegisterInput = {
   deviceInfo: DeviceInfo;
 };
 
-const register = async ({ username, email, password, deviceInfo }: RegisterInput) => {
+const register = async ({
+  username,
+  email,
+  password,
+  deviceInfo,
+}: RegisterInput) => {
   const emailExists = await prisma.user.findFirst({
     where: { email, isDeleted: false },
     select: { id: true, createdAt: true, authProvider: true, isVerified: true },

--- a/src/services/auth/resendResetPasswordEmail.service.ts
+++ b/src/services/auth/resendResetPasswordEmail.service.ts
@@ -41,7 +41,10 @@ const resendResetPasswordEmail = async ({
   if (!foundUser) throw new HttpError("Invalid credentials", 404);
 
   if (await handleExpiredUnverifiedUser(foundUser)) {
-    throw new HttpError("Email verification expired, please sign up again", 410);
+    throw new HttpError(
+      "Email verification expired, please sign up again",
+      410,
+    );
   }
 
   if (foundUser.authProvider !== "LOCAL")
@@ -57,7 +60,9 @@ const resendResetPasswordEmail = async ({
   if (foundUser.resetPasswordOtpResendAvailableAt > new Date(Date.now()))
     throw new HttpError("OTP resend will soon be available, please wait", 400);
 
-  const resetPasswordOtp = Math.floor(100000 + Math.random() * 900000).toString();
+  const resetPasswordOtp = Math.floor(
+    100000 + Math.random() * 900000,
+  ).toString();
   const resetPasswordOtpExpireAt = new Date(Date.now() + 2 * 60 * 1000);
   const resetPasswordOtpResendAvailableAt = new Date(Date.now() + 30 * 1000);
 

--- a/src/services/auth/resendVerificationEmail.service.ts
+++ b/src/services/auth/resendVerificationEmail.service.ts
@@ -28,7 +28,10 @@ const resendVerificationEmail = async ({
   if (!foundUser) throw new HttpError("Invalid credentials", 404);
 
   if (await handleExpiredUnverifiedUser(foundUser)) {
-    throw new HttpError("Email verification expired, please sign up again", 410);
+    throw new HttpError(
+      "Email verification expired, please sign up again",
+      410,
+    );
   }
 
   if (foundUser.authProvider !== "LOCAL")
@@ -36,7 +39,11 @@ const resendVerificationEmail = async ({
 
   if (foundUser.isVerified) throw new HttpError("User already verified", 400);
 
-  if (!foundUser.otpExpireAt || !foundUser.otpResendAvailableAt || !foundUser.otp)
+  if (
+    !foundUser.otpExpireAt ||
+    !foundUser.otpResendAvailableAt ||
+    !foundUser.otp
+  )
     throw new HttpError("OTP not set", 400);
 
   if (foundUser.otpResendAvailableAt > new Date(Date.now()))

--- a/src/services/auth/resetPassword.service.ts
+++ b/src/services/auth/resetPassword.service.ts
@@ -6,7 +6,10 @@ import publishSocketDisconnect from "../../utils/publishSocketDisconnect.util.js
 import prisma from "../../config/prisma.config.js";
 import { getRedisCacheClient } from "../../config/redis.config.js";
 
-import { handleExpiredUnverifiedUser, removeResetPasswordAttempts } from "./auth.shared.js";
+import {
+  handleExpiredUnverifiedUser,
+  removeResetPasswordAttempts,
+} from "./auth.shared.js";
 
 type ResetPasswordInput = {
   email: string;
@@ -31,7 +34,10 @@ const resetPassword = async ({ email, newPassword }: ResetPasswordInput) => {
   if (!foundUser) throw new HttpError("Invalid credentials", 404);
 
   if (await handleExpiredUnverifiedUser(foundUser)) {
-    throw new HttpError("Email verification expired, please sign up again", 410);
+    throw new HttpError(
+      "Email verification expired, please sign up again",
+      410,
+    );
   }
 
   if (foundUser.authProvider !== "LOCAL")
@@ -46,7 +52,10 @@ const resetPassword = async ({ email, newPassword }: ResetPasswordInput) => {
   );
 
   if (isSamePassword)
-    throw new HttpError("New password must be different from the old password", 400);
+    throw new HttpError(
+      "New password must be different from the old password",
+      400,
+    );
 
   const hashedPassword = await bcrypt.hash(newPassword, 10);
 

--- a/src/services/auth/sendResetPasswordEmail.service.ts
+++ b/src/services/auth/sendResetPasswordEmail.service.ts
@@ -50,7 +50,9 @@ const sendResetPasswordEmail = async ({
     if (foundUser.resetPasswordOtpExpireAt > new Date(Date.now()))
       throw new HttpError("Reset password OTP already sent", 400);
 
-  const resetPasswordOtp = Math.floor(100000 + Math.random() * 900000).toString();
+  const resetPasswordOtp = Math.floor(
+    100000 + Math.random() * 900000,
+  ).toString();
   const resetPasswordOtpExpireAt = new Date(Date.now() + 2 * 60 * 1000);
   const resetPasswordOtpResendAvailableAt = new Date(Date.now() + 30 * 1000);
 

--- a/src/services/auth/verifyEmail.service.ts
+++ b/src/services/auth/verifyEmail.service.ts
@@ -18,7 +18,10 @@ const verifyEmail = async ({ userId, otp: inputOtp }: VerifyEmailInput) => {
   if (!foundUser) throw new HttpError("Invalid credentials", 404);
 
   if (await handleExpiredUnverifiedUser(foundUser)) {
-    throw new HttpError("Email verification expired, please sign up again", 410);
+    throw new HttpError(
+      "Email verification expired, please sign up again",
+      410,
+    );
   }
 
   if (foundUser.authProvider !== "LOCAL")
@@ -26,7 +29,11 @@ const verifyEmail = async ({ userId, otp: inputOtp }: VerifyEmailInput) => {
 
   if (foundUser.isVerified) throw new HttpError("User already verified", 400);
 
-  if (!foundUser.otpExpireAt || !foundUser.otpResendAvailableAt || !foundUser.otp)
+  if (
+    !foundUser.otpExpireAt ||
+    !foundUser.otpResendAvailableAt ||
+    !foundUser.otp
+  )
     throw new HttpError("OTP not set", 400);
 
   const attempts = await getRedisCacheClient().get(

--- a/src/services/auth/verifyResetPasswordOtp.service.ts
+++ b/src/services/auth/verifyResetPasswordOtp.service.ts
@@ -5,7 +5,10 @@ import HttpError from "../../utils/httpError.util.js";
 import prisma from "../../config/prisma.config.js";
 import { getRedisCacheClient } from "../../config/redis.config.js";
 
-import { handleExpiredUnverifiedUser, removeResetPasswordAttempts } from "./auth.shared.js";
+import {
+  handleExpiredUnverifiedUser,
+  removeResetPasswordAttempts,
+} from "./auth.shared.js";
 
 type VerifyResetPasswordOtpInput = {
   email: string;
@@ -34,7 +37,10 @@ const verifyResetPasswordOtp = async ({
   if (!foundUser) throw new HttpError("Invalid credentials", 404);
 
   if (await handleExpiredUnverifiedUser(foundUser)) {
-    throw new HttpError("Email verification expired, please sign up again", 410);
+    throw new HttpError(
+      "Email verification expired, please sign up again",
+      410,
+    );
   }
 
   if (foundUser.authProvider !== "LOCAL")

--- a/src/services/question/createFeedbackOnAiAnswer.service.ts
+++ b/src/services/question/createFeedbackOnAiAnswer.service.ts
@@ -73,7 +73,11 @@ const createFeedbackOnAiAnswerService = async (
     {
       removeOnComplete: true,
       removeOnFail: false,
-      jobId: makeJobId("contentModeration", "AI_ANSWER_FEEDBACK", newFeedback._id),
+      jobId: makeJobId(
+        "contentModeration",
+        "AI_ANSWER_FEEDBACK",
+        newFeedback._id,
+      ),
     },
   );
 

--- a/src/services/question/editFeedbackOnAiAnswer.service.ts
+++ b/src/services/question/editFeedbackOnAiAnswer.service.ts
@@ -55,11 +55,9 @@ const editFeedbackOnAiAnswer = async (
     throw new HttpError("Question version not found", 404);
 
   const hasNoChanges =
-    type === foundFeedback.type &&
-    body === (foundFeedback.body ?? null)
+    type === foundFeedback.type && body === (foundFeedback.body ?? null);
 
-  if (hasNoChanges)
-    throw new HttpError("No changes made to the feedback", 400);
+  if (hasNoChanges) throw new HttpError("No changes made to the feedback", 400);
 
   const editedFeedback = await AiAnswerFeedback.findByIdAndUpdate(
     feedbackId,

--- a/src/services/redis/editSession.service.ts
+++ b/src/services/redis/editSession.service.ts
@@ -1,13 +1,7 @@
 import { getRedisCacheClient } from "../../config/redis.config.js";
 
-const startEditSession = async (
-  socketId: string,
-  version: number,
-) => {
-  await getRedisCacheClient().sadd(
-    `edit:version:${version}:sockets`,
-    socketId,
-  );
+const startEditSession = async (socketId: string, version: number) => {
+  await getRedisCacheClient().sadd(`edit:version:${version}:sockets`, socketId);
   await getRedisCacheClient().set(`edit:socket:${socketId}`, version);
 };
 
@@ -16,10 +10,7 @@ const endEditSession = async (socketId: string) => {
 
   if (!version) return;
 
-  await getRedisCacheClient().srem(
-    `edit:version:${version}:sockets`,
-    socketId,
-  );
+  await getRedisCacheClient().srem(`edit:version:${version}:sockets`, socketId);
 
   const remaining = await getRedisCacheClient().scard(
     `edit:version:${version}:sockets`,

--- a/src/sockets/subscribers/socketDisconnect.subscriber.ts
+++ b/src/sockets/subscribers/socketDisconnect.subscriber.ts
@@ -6,8 +6,7 @@ const CHANNEL = "socket:disconnect";
 
 const initSocketDisconnectSubscriber = () => {
   registerSubscriber(CHANNEL, async (payload) => {
-    const userId =
-      typeof payload === "string" ? payload : payload?.userId;
+    const userId = typeof payload === "string" ? payload : payload?.userId;
 
     if (!userId) return;
 

--- a/src/utils/makeJobId.util.ts
+++ b/src/utils/makeJobId.util.ts
@@ -13,4 +13,3 @@ export const makeJobId = (...parts: unknown[]) =>
 
 export const makeUniqueJobId = (...parts: unknown[]) =>
   makeJobId(...parts, crypto.randomUUID());
-

--- a/src/utils/publishSocketDisconnect.util.ts
+++ b/src/utils/publishSocketDisconnect.util.ts
@@ -2,10 +2,7 @@ import { getRedisPub } from "../redis/redis.pubsub.js";
 
 const publishSocketDisconnect = async (userId: string) => {
   console.log("[socket:disconnect:publish]", { userId });
-  await getRedisPub().publish(
-    "socket:disconnect",
-    JSON.stringify({ userId }),
-  );
+  await getRedisPub().publish("socket:disconnect", JSON.stringify({ userId }));
 };
 
 export default publishSocketDisconnect;

--- a/src/validations/auth.schema.ts
+++ b/src/validations/auth.schema.ts
@@ -24,7 +24,10 @@ const passwordSchema = z
   .max(60, "Password must be at most 60 characters")
   .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
   .regex(/[a-z]/, "Password must contain at least one lowercase letter")
-  .regex(/[^a-zA-Z]/, "Password must contain at least one non-letter character");
+  .regex(
+    /[^a-zA-Z]/,
+    "Password must contain at least one non-letter character",
+  );
 
 const otpSchema = z.string().length(6, "OTP should be exactly 6 characters");
 

--- a/src/workers/accountDeletion.worker.ts
+++ b/src/workers/accountDeletion.worker.ts
@@ -1,11 +1,14 @@
 import { Worker } from "bullmq";
-
-import { redisMessagingClientConnection } from "../config/redis.config.js";
-import connectMongoDB from "../config/mongodb.config.js";
+import { fileURLToPath } from "node:url";
 
 import deleteAccount from "../services/auth/deleteAccount.service.js";
 
-async function startWorker() {
+import connectMongoDB from "../config/mongodb.config.js";
+import { redisMessagingClientConnection } from "../config/redis.config.js";
+
+const workerFilePath = fileURLToPath(import.meta.url);
+
+async function startAccountDeletionWorker() {
   await connectMongoDB(process.env.MONGO_URI as string);
   console.log("Mongo connected, starting account deletion worker...");
 
@@ -34,9 +37,17 @@ async function startWorker() {
   worker.on("error", (err) => {
     console.error("Worker crashed:", err);
   });
+
+  return worker;
 }
 
-startWorker().catch((error) => {
-  console.error("Failed to start account deletion worker:", error);
-  process.exit(1);
-});
+const isDirectRun = process.argv[1] === workerFilePath;
+
+if (isDirectRun) {
+  void startAccountDeletionWorker().catch((error) => {
+    console.error("Failed to start account deletion worker:", error);
+    process.exit(1);
+  });
+}
+
+export { startAccountDeletionWorker };

--- a/src/workers/accountDeletion.worker.ts
+++ b/src/workers/accountDeletion.worker.ts
@@ -12,7 +12,9 @@ async function startWorker() {
   const worker = new Worker(
     "accountDeletionQueue",
     async (job) => {
-      await deleteAccount(job.data as { userId: string; profilePictureKey?: string | null });
+      await deleteAccount(
+        job.data as { userId: string; profilePictureKey?: string | null },
+      );
     },
     {
       connection: redisMessagingClientConnection,

--- a/src/workers/aiAnswer.worker.ts
+++ b/src/workers/aiAnswer.worker.ts
@@ -97,7 +97,7 @@ async function startWorker() {
               topicStatus: "VALID",
             },
           },
-          
+
           { $limit: 5 },
         ]);
 

--- a/src/workers/email.worker.ts
+++ b/src/workers/email.worker.ts
@@ -1,67 +1,84 @@
 import { Worker } from "bullmq";
-import { redisMessagingClientConnection } from "../config/redis.config.js";
-
-import prisma from "../config/prisma.config.js";
-
-import transporter from "../config/nodemailer.config.js";
+import { fileURLToPath } from "node:url";
 
 import { isExpiredUnverifiedLocalUser } from "../services/auth/unverifiedAccountCleanup.service.js";
 
-const worker = new Worker(
-  "emailQueue",
-  async (job) => {
-    const { email, subject, htmlContent, userId, purpose } = job.data;
+import { redisMessagingClientConnection } from "../config/redis.config.js";
+import prisma from "../config/prisma.config.js";
+import transporter from "../config/nodemailer.config.js";
 
-    if (userId) {
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: {
-          id: true,
-          email: true,
-          createdAt: true,
-          authProvider: true,
-          isVerified: true,
-          isDeleted: true,
-        },
-      });
+const workerFilePath = fileURLToPath(import.meta.url);
 
-      if (!user) return;
+async function startEmailWorker() {
+  const worker = new Worker(
+    "emailQueue",
+    async (job) => {
+      const { email, subject, htmlContent, userId, purpose } = job.data;
 
-      if (user.isDeleted || user.authProvider !== "LOCAL") return;
+      if (userId) {
+        const user = await prisma.user.findUnique({
+          where: { id: userId },
+          select: {
+            id: true,
+            email: true,
+            createdAt: true,
+            authProvider: true,
+            isVerified: true,
+            isDeleted: true,
+          },
+        });
 
-      if (
-        purpose === "VERIFY_EMAIL" &&
-        (user.isVerified || isExpiredUnverifiedLocalUser(user))
-      ) {
-        return;
+        if (!user) return;
+
+        if (user.isDeleted || user.authProvider !== "LOCAL") return;
+
+        if (
+          purpose === "VERIFY_EMAIL" &&
+          (user.isVerified || isExpiredUnverifiedLocalUser(user))
+        ) {
+          return;
+        }
       }
-    }
 
-    await transporter.sendMail({
-      from: `'Qanopy' <${process.env.QANOPY_EMAIL}>`,
-      to: email,
-      subject,
-      html: htmlContent,
-    });
-  },
-  {
-    connection: redisMessagingClientConnection,
-    concurrency: 20,
-    limiter: {
-      max: 20,
-      duration: 1000,
+      await transporter.sendMail({
+        from: `'Qanopy' <${process.env.QANOPY_EMAIL}>`,
+        to: email,
+        subject,
+        html: htmlContent,
+      });
     },
-  },
-);
+    {
+      connection: redisMessagingClientConnection,
+      concurrency: 20,
+      limiter: {
+        max: 20,
+        duration: 1000,
+      },
+    },
+  );
 
-worker.on("completed", (job) => {
-  console.log(`Job ${job.id} completed`);
-});
+  worker.on("completed", (job) => {
+    console.log(`Job ${job.id} completed`);
+  });
 
-worker.on("failed", (job, err) => {
-  console.error(`Job ${job?.id} failed:`, err);
-});
+  worker.on("failed", (job, err) => {
+    console.error(`Job ${job?.id} failed:`, err);
+  });
 
-worker.on("error", (err) => {
-  console.error("Worker crashed:", err);
-});
+  worker.on("error", (err) => {
+    console.error("Worker crashed:", err);
+  });
+
+  return worker;
+}
+
+const isDirectRun = process.argv[1] === workerFilePath;
+
+if (isDirectRun) {
+  void startEmailWorker().catch((error) => {
+    console.error("Failed to start email worker:", error);
+    process.exit(1);
+  });
+}
+
+export { startEmailWorker };

--- a/src/workers/unverifiedAccountCleanup.worker.ts
+++ b/src/workers/unverifiedAccountCleanup.worker.ts
@@ -3,9 +3,7 @@ import { Worker } from "bullmq";
 import { redisMessagingClientConnection } from "../config/redis.config.js";
 
 import unverifiedAccountCleanupQueue from "../queues/unverifiedAccountCleanup.queue.js";
-import {
-  cleanupAllExpiredUnverifiedUsers,
-} from "../services/auth/unverifiedAccountCleanup.service.js";
+import { cleanupAllExpiredUnverifiedUsers } from "../services/auth/unverifiedAccountCleanup.service.js";
 
 const CLEANUP_JOB_NAME = "CLEANUP_EXPIRED_UNVERIFIED_ACCOUNTS";
 const CLEANUP_REPEAT_EVERY_MS = 60 * 60 * 1000;

--- a/src/workers/unverifiedAccountCleanup.worker.ts
+++ b/src/workers/unverifiedAccountCleanup.worker.ts
@@ -1,14 +1,17 @@
 import { Worker } from "bullmq";
+import { fileURLToPath } from "node:url";
 
+import { cleanupAllExpiredUnverifiedUsers } from "../services/auth/unverifiedAccountCleanup.service.js";
 import { redisMessagingClientConnection } from "../config/redis.config.js";
 
 import unverifiedAccountCleanupQueue from "../queues/unverifiedAccountCleanup.queue.js";
-import { cleanupAllExpiredUnverifiedUsers } from "../services/auth/unverifiedAccountCleanup.service.js";
 
 const CLEANUP_JOB_NAME = "CLEANUP_EXPIRED_UNVERIFIED_ACCOUNTS";
 const CLEANUP_REPEAT_EVERY_MS = 60 * 60 * 1000;
 
-async function startWorker() {
+const workerFilePath = fileURLToPath(import.meta.url);
+
+async function startUnverifiedAccountCleanupWorker() {
   const initialCleanedCount = await cleanupAllExpiredUnverifiedUsers();
   console.log("[unverifiedAccountCleanup:init]", { initialCleanedCount });
 
@@ -59,9 +62,21 @@ async function startWorker() {
   worker.on("error", (err) => {
     console.error("Worker crashed:", err);
   });
+
+  return worker;
 }
 
-startWorker().catch((error) => {
-  console.error("Failed to start unverified account cleanup worker:", error);
-  process.exit(1);
-});
+const isDirectRun = process.argv[1] === workerFilePath;
+
+if (isDirectRun) {
+  void startUnverifiedAccountCleanupWorker().catch((error) => {
+    console.error("Failed to start unverified account cleanup worker:", error);
+    process.exit(1);
+  });
+}
+
+export {
+  CLEANUP_JOB_NAME,
+  CLEANUP_REPEAT_EVERY_MS,
+  startUnverifiedAccountCleanupWorker,
+};

--- a/src/workers/userInterest.worker.ts
+++ b/src/workers/userInterest.worker.ts
@@ -56,10 +56,7 @@ async function applyInterestScore(userId: string, tag: string, score: number) {
                     },
                   },
                   {
-                    $concatArrays: [
-                      "$$existingInterests",
-                      [{ tag, score }],
-                    ],
+                    $concatArrays: ["$$existingInterests", [{ tag, score }]],
                   },
                 ],
               },

--- a/tests/helpers/createAuthServiceModuleMock.ts
+++ b/tests/helpers/createAuthServiceModuleMock.ts
@@ -1,0 +1,31 @@
+import { vi } from "vitest";
+
+type AuthServiceModuleMockOverrides = Partial<{
+  register: ReturnType<typeof vi.fn>;
+  login: ReturnType<typeof vi.fn>;
+  registerOrLogin: ReturnType<typeof vi.fn>;
+  verifyEmail: ReturnType<typeof vi.fn>;
+  resendVerificationEmail: ReturnType<typeof vi.fn>;
+  sendResetPasswordEmail: ReturnType<typeof vi.fn>;
+  resendResetPasswordEmail: ReturnType<typeof vi.fn>;
+  verifyResetPasswordOtp: ReturnType<typeof vi.fn>;
+  resetPassword: ReturnType<typeof vi.fn>;
+  changePassword: ReturnType<typeof vi.fn>;
+  isAuth: ReturnType<typeof vi.fn>;
+}>;
+
+export const createAuthServiceModuleMock = (
+  overrides: AuthServiceModuleMockOverrides = {},
+) => ({
+  register: overrides.register ?? vi.fn(),
+  login: overrides.login ?? vi.fn(),
+  registerOrLogin: overrides.registerOrLogin ?? vi.fn(),
+  verifyEmail: overrides.verifyEmail ?? vi.fn(),
+  resendVerificationEmail: overrides.resendVerificationEmail ?? vi.fn(),
+  sendResetPasswordEmail: overrides.sendResetPasswordEmail ?? vi.fn(),
+  resendResetPasswordEmail: overrides.resendResetPasswordEmail ?? vi.fn(),
+  verifyResetPasswordOtp: overrides.verifyResetPasswordOtp ?? vi.fn(),
+  resetPassword: overrides.resetPassword ?? vi.fn(),
+  changePassword: overrides.changePassword ?? vi.fn(),
+  isAuth: overrides.isAuth ?? vi.fn(),
+});

--- a/tests/helpers/createGraphqlAuthContext.ts
+++ b/tests/helpers/createGraphqlAuthContext.ts
@@ -1,0 +1,28 @@
+import createUserLoader from "../../src/dataloaders/user.loader.js";
+import authenticateGraphQLUser from "../../src/middlewares/graphqlAuth.middleware.js";
+
+import prisma from "../../src/config/prisma.config.js";
+import { getRedisCacheClient } from "../../src/config/redis.config.js";
+
+const createGraphqlAuthContext = async (req: {
+  cookies?: {
+    token?: string;
+  };
+  headers?: {
+    authorization?: string;
+  };
+}) => {
+  const user = await authenticateGraphQLUser(req as any);
+
+  return {
+    token: req.headers?.authorization,
+    prisma,
+    getRedisCacheClient,
+    user,
+    loaders: {
+      userLoader: createUserLoader(),
+    },
+  };
+};
+
+export default createGraphqlAuthContext;

--- a/tests/helpers/createMiddlewareTestApp.ts
+++ b/tests/helpers/createMiddlewareTestApp.ts
@@ -1,0 +1,47 @@
+import express, { type RequestHandler } from "express";
+import cookieParser from "cookie-parser";
+
+type MiddlewareTestAppOptions = {
+  method?: "get" | "post" | "put" | "patch" | "delete";
+  path?: string;
+  middlewares: RequestHandler[];
+  handler?: RequestHandler;
+};
+
+const createMiddlewareTestApp = ({
+  method = "get",
+  path = "/test",
+  middlewares,
+  handler = (_req, res) => {
+    res.status(200).json({ message: "ok" });
+  },
+}: MiddlewareTestAppOptions) => {
+  const app = express();
+
+  app.use(express.json());
+  app.use(cookieParser());
+
+  const routeHandler = [...middlewares, handler];
+
+  switch (method) {
+    case "get":
+      app.get(path, ...routeHandler);
+      break;
+    case "post":
+      app.post(path, ...routeHandler);
+      break;
+    case "put":
+      app.put(path, ...routeHandler);
+      break;
+    case "patch":
+      app.patch(path, ...routeHandler);
+      break;
+    case "delete":
+      app.delete(path, ...routeHandler);
+      break;
+  }
+
+  return app;
+};
+
+export default createMiddlewareTestApp;

--- a/tests/helpers/createSocketTestServer.ts
+++ b/tests/helpers/createSocketTestServer.ts
@@ -1,0 +1,84 @@
+import http from "http";
+import path from "path";
+import { createRequire } from "module";
+import type { AddressInfo } from "net";
+
+import type { Socket } from "socket.io";
+
+import initSocket, { io } from "../../src/sockets/index.js";
+
+const require = createRequire(import.meta.url);
+const { io: createSocketClient } = require(
+  path.resolve(
+    process.cwd(),
+    "node_modules/socket.io/client-dist/socket.io.js",
+  ),
+);
+
+type SocketTestServer = {
+  close: () => Promise<void>;
+  connect: (token?: string) => Promise<Socket>;
+  port: number;
+  url: string;
+};
+
+const createSocketTestServer = async (): Promise<SocketTestServer> => {
+  const server = http.createServer();
+
+  initSocket(server);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.once("listening", resolve);
+    server.listen(0);
+  });
+
+  const address = server.address() as AddressInfo;
+  const port = address.port;
+  const url = `http://127.0.0.1:${port}`;
+
+  const close = async () => {
+    await new Promise<void>((resolve) => {
+      io?.close(() => resolve());
+    });
+
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  };
+
+  const connect = (token?: string) =>
+    new Promise<Socket>((resolve, reject) => {
+      const socket = createSocketClient(url, {
+        auth: token ? { token } : {},
+        forceNew: true,
+        reconnection: false,
+        timeout: 1000,
+        transports: ["websocket"],
+      });
+
+      const connectTimeout = setTimeout(() => {
+        socket.close();
+        reject(new Error("Socket connection timed out"));
+      }, 5000);
+
+      socket.on("connect", () => {
+        clearTimeout(connectTimeout);
+        resolve(socket);
+      });
+      socket.on("connect_error", (error: Error) => {
+        clearTimeout(connectTimeout);
+        socket.close();
+        reject(error);
+      });
+    });
+
+  return {
+    close,
+    connect,
+    port,
+    url,
+  };
+};
+
+export default createSocketTestServer;

--- a/tests/helpers/createTestApp.ts
+++ b/tests/helpers/createTestApp.ts
@@ -1,0 +1,50 @@
+type CreateTestAppOptions = {
+  includeAuthRoutes?: boolean;
+  includeUserRoutes?: boolean;
+  includeQuestionRoutes?: boolean;
+  includeModerationRoutes?: boolean;
+};
+
+export const createTestApp = async ({
+  includeAuthRoutes = true,
+  includeUserRoutes = true,
+  includeQuestionRoutes = true,
+  includeModerationRoutes = true,
+}: CreateTestAppOptions = {}) => {
+  const { default: createApp } = await import("../../src/app.js");
+
+  return createApp({
+    includeAuthRoutes,
+    includeUserRoutes,
+    includeQuestionRoutes,
+    includeModerationRoutes,
+  });
+};
+
+export const createAuthTestApp = async () =>
+  createTestApp({
+    includeUserRoutes: false,
+    includeQuestionRoutes: false,
+    includeModerationRoutes: false,
+  });
+
+export const createUserTestApp = async () =>
+  createTestApp({
+    includeAuthRoutes: false,
+    includeQuestionRoutes: false,
+    includeModerationRoutes: false,
+  });
+
+export const createQuestionTestApp = async () =>
+  createTestApp({
+    includeAuthRoutes: false,
+    includeUserRoutes: false,
+    includeModerationRoutes: false,
+  });
+
+export const createModerationTestApp = async () =>
+  createTestApp({
+    includeAuthRoutes: false,
+    includeUserRoutes: false,
+    includeQuestionRoutes: false,
+  });

--- a/tests/helpers/mockAuthContext.ts
+++ b/tests/helpers/mockAuthContext.ts
@@ -1,0 +1,95 @@
+type MockAuthUser = {
+  id: string;
+  tokenVersion: number;
+  status: string;
+  isVerified: boolean;
+  role: string;
+  isDeleted: boolean;
+};
+
+type MockAuthError = {
+  status: number;
+  message: string;
+};
+
+type MockAuthContextState = {
+  authenticated: boolean;
+  authError: MockAuthError;
+  user: MockAuthUser;
+};
+
+const defaultUser: MockAuthUser = {
+  id: "user_1",
+  tokenVersion: 0,
+  status: "ACTIVE",
+  isVerified: true,
+  role: "USER",
+  isDeleted: false,
+};
+
+export const mockAuthContextState: MockAuthContextState = {
+  authenticated: true,
+  authError: {
+    status: 400,
+    message: "Not authenticated, no token",
+  },
+  user: { ...defaultUser },
+};
+
+export const resetMockAuthContextState = () => {
+  mockAuthContextState.authenticated = true;
+  mockAuthContextState.authError = {
+    status: 400,
+    message: "Not authenticated, no token",
+  };
+  mockAuthContextState.user = { ...defaultUser };
+};
+
+export const createMockAuthMiddlewareModule = () => ({
+  default: (req: any, res: any, next: () => void) => {
+    if (!mockAuthContextState.authenticated) {
+      return res
+        .status(mockAuthContextState.authError.status)
+        .json({ message: mockAuthContextState.authError.message });
+    }
+
+    if (mockAuthContextState.user.isDeleted) {
+      return res.status(403).json({ message: "User not active" });
+    }
+
+    req.user = { ...mockAuthContextState.user };
+    return next();
+  },
+  requireLoggedOut: (_req: any, res: any, next: () => void) => {
+    if (mockAuthContextState.authenticated) {
+      return res
+        .status(400)
+        .json({ message: "This action is only available when logged out" });
+    }
+
+    return next();
+  },
+  isVerified: (req: any, res: any, next: () => void) => {
+    if (!req.user?.isVerified) {
+      return res.status(403).json({ message: "User not verified" });
+    }
+
+    return next();
+  },
+  requireActiveUser: (req: any, res: any, next: () => void) => {
+    if (req.user?.status !== "ACTIVE") {
+      return res.status(403).json({ message: "User not active" });
+    }
+
+    return next();
+  },
+  isAdmin: (req: any, res: any, next: () => void) => {
+    if (req.user?.role !== "ADMIN") {
+      return res
+        .status(403)
+        .json({ message: "User forbidden accessing this route" });
+    }
+
+    return next();
+  },
+});

--- a/tests/helpers/mockAuthLimiters.ts
+++ b/tests/helpers/mockAuthLimiters.ts
@@ -1,0 +1,14 @@
+const passThrough = (_req: unknown, _res: unknown, next: () => void) => next();
+
+export const mockAuthLimiters = {
+  registerLimiterMiddleware: passThrough,
+  loginLimiterMiddleware: passThrough,
+  oauthLimiterMiddleware: passThrough,
+  emailVerificationLimiterMiddleware: passThrough,
+  resendEmailLimiterMiddleware: passThrough,
+  passwordResetLimiterMiddleware: passThrough,
+  userEmailVerificationLimiterMiddleware: passThrough,
+  userResendEmailLimiterMiddleware: passThrough,
+  userPasswordChangeLimiterMiddleware: passThrough,
+  sessionLimiterMiddleware: passThrough,
+};

--- a/tests/helpers/mockAuthMiddlewareEnvironment.ts
+++ b/tests/helpers/mockAuthMiddlewareEnvironment.ts
@@ -1,0 +1,89 @@
+import { vi } from "vitest";
+
+type DecodedToken = {
+  userId: string;
+  tokenVersion?: number;
+};
+
+type AuthUser = {
+  id: string;
+  tokenVersion: number;
+  status: string;
+  isVerified: boolean;
+  role: string;
+  isDeleted: boolean;
+};
+
+const prismaUserFindUnique = vi.fn();
+const redisStore = new Map<string, string>();
+const jwtPayloads = new Map<string, DecodedToken>();
+
+const redisGet = vi.fn(async (key: string) => redisStore.get(key) ?? null);
+const redisSet = vi.fn(async (key: string, value: string) => {
+  redisStore.set(key, value);
+  return "OK";
+});
+const redisDel = vi.fn(async (key: string) => {
+  redisStore.delete(key);
+  return 1;
+});
+
+const jwtVerify = vi.fn((token: string) => {
+  const payload = jwtPayloads.get(token);
+
+  if (!payload) throw new Error("invalid token");
+
+  return payload;
+});
+
+export const authMiddlewareEnvironment = {
+  prismaUserFindUnique,
+  redisStore,
+  jwtPayloads,
+  redisGet,
+  redisSet,
+  redisDel,
+  jwtVerify,
+};
+
+export const resetAuthMiddlewareEnvironment = () => {
+  redisStore.clear();
+  jwtPayloads.clear();
+
+  prismaUserFindUnique.mockReset();
+  redisGet.mockClear();
+  redisSet.mockClear();
+  redisDel.mockClear();
+  jwtVerify.mockClear();
+};
+
+export const seedJwtPayload = (token: string, payload: DecodedToken) => {
+  jwtPayloads.set(token, payload);
+};
+
+export const seedRedisAuthUser = (user: AuthUser) => {
+  redisStore.set(`auth:user:${user.id}`, JSON.stringify(user));
+};
+
+export const mockAuthMiddlewareModules = {
+  jsonwebtoken: {
+    default: {
+      verify: jwtVerify,
+      sign: vi.fn(),
+    },
+  },
+  prismaConfig: {
+    default: {
+      user: {
+        findUnique: prismaUserFindUnique,
+      },
+    },
+  },
+  redisConfig: {
+    getRedisCacheClient: () => ({
+      get: redisGet,
+      set: redisSet,
+      del: redisDel,
+    }),
+  },
+};

--- a/tests/helpers/mockAuthMiddlewares.ts
+++ b/tests/helpers/mockAuthMiddlewares.ts
@@ -1,0 +1,9 @@
+const passThrough = (_req: unknown, _res: unknown, next: () => void) => next();
+
+export const mockAuthMiddlewares = {
+  default: passThrough,
+  requireLoggedOut: passThrough,
+  isVerified: passThrough,
+  requireActiveUser: passThrough,
+  isAdmin: passThrough,
+};

--- a/tests/helpers/mockAuthUnitTestEnvironment.ts
+++ b/tests/helpers/mockAuthUnitTestEnvironment.ts
@@ -1,0 +1,290 @@
+import { vi } from "vitest";
+
+type RedisEntry = string;
+
+type BcryptCompareKey = `${string}::${string}`;
+
+const redisStore = new Map<string, RedisEntry>();
+const bcryptCompareResults = new Map<BcryptCompareKey, boolean>();
+
+const prismaUserFindFirst = vi.fn();
+const prismaUserFindUnique = vi.fn();
+const prismaUserFindMany = vi.fn();
+const prismaUserCreate = vi.fn();
+const prismaUserUpdate = vi.fn();
+const prismaUserDeleteMany = vi.fn();
+const prismaUserDelete = vi.fn();
+const prismaTransaction = vi.fn(async (cb: (tx: any) => Promise<unknown>) =>
+  cb(prismaMocks.transactionClient),
+);
+const prismaFindUniqueByUsername = vi.fn();
+const prismaDeleteManyGeneric = vi.fn();
+const prismaDeleteManyNotificationSettings = vi.fn();
+const prismaDeleteManyModerationStats = vi.fn();
+const prismaDeleteManyBan = vi.fn();
+const prismaDeleteManyWarning = vi.fn();
+const prismaDeleteManyModerationStrike = vi.fn();
+const prismaDeleteManyAchievement = vi.fn();
+
+const redisGet = vi.fn(async (key: string) => redisStore.get(key) ?? null);
+const redisSet = vi.fn(async (key: string, value: string) => {
+  redisStore.set(key, value);
+  return "OK";
+});
+const redisDel = vi.fn(async (...keys: string[]) => {
+  keys.forEach((key) => redisStore.delete(key));
+  return keys.length;
+});
+const redisScan = vi.fn(async () => ["0", []] as const);
+
+const redisMultiChain = {
+  incr: vi.fn().mockReturnThis(),
+  expire: vi.fn().mockReturnThis(),
+  exec: vi.fn(async () => []),
+};
+const redisMulti = vi.fn(() => redisMultiChain);
+
+const bcryptHash = vi.fn(
+  async (value: string, rounds: number) => `hashed:${value}:${rounds}`,
+);
+const bcryptCompare = vi.fn(async (value: string, hashed: string) => {
+  const seeded = bcryptCompareResults.get(`${value}::${hashed}`);
+  return seeded ?? value === hashed;
+});
+
+const emailQueueAdd = vi.fn(async () => ({
+  id: "job-id",
+}));
+
+const verifyGoogleToken = vi.fn();
+const generateOAuthUsername = vi.fn();
+const makeUniqueJobId = vi.fn(() => "unique-job-id");
+const verificationHtml = vi.fn(() => "<verification-email>");
+const resetPasswordHtml = vi.fn(() => "<reset-password-email>");
+const publishSocketDisconnect = vi.fn(async () => undefined);
+const deleteSingleImageService = vi.fn(async () => undefined);
+const buildDeletedUserData = vi.fn(async () => ({
+  status: "DELETED",
+  isDeleted: true,
+}));
+const clearNotificationCache = vi.fn(async () => undefined);
+const cleanupExpiredUnverifiedUserById = vi.fn(async () => false);
+const isExpiredUnverifiedLocalUser = vi.fn(() => false);
+
+const notificationDeleteMany = vi.fn(async () => ({ count: 0 }));
+const userInterestDeleteMany = vi.fn(async () => ({ count: 0 }));
+
+const prismaMocks = {
+  transactionClient: {
+    user: {
+      create: prismaUserCreate,
+    },
+  },
+  user: {
+    findFirst: prismaUserFindFirst,
+    findUnique: prismaUserFindUnique,
+    findMany: prismaUserFindMany,
+    create: prismaUserCreate,
+    update: prismaUserUpdate,
+    deleteMany: prismaUserDeleteMany,
+    delete: prismaUserDelete,
+  },
+  achievement: {
+    deleteMany: prismaDeleteManyAchievement,
+  },
+  moderationStrike: {
+    deleteMany: prismaDeleteManyModerationStrike,
+  },
+  warning: {
+    deleteMany: prismaDeleteManyWarning,
+  },
+  ban: {
+    deleteMany: prismaDeleteManyBan,
+  },
+  moderationStats: {
+    deleteMany: prismaDeleteManyModerationStats,
+  },
+  notificationSettings: {
+    deleteMany: prismaDeleteManyNotificationSettings,
+  },
+  $transaction: prismaTransaction,
+};
+
+export const mockAuthUnitModules = {
+  prismaConfig: {
+    default: prismaMocks,
+  },
+  redisConfig: {
+    getRedisCacheClient: () => ({
+      get: redisGet,
+      set: redisSet,
+      del: redisDel,
+      multi: redisMulti,
+      scan: redisScan,
+    }),
+  },
+  bcrypt: {
+    default: {
+      hash: bcryptHash,
+      compare: bcryptCompare,
+    },
+  },
+  emailQueue: {
+    default: {
+      add: emailQueueAdd,
+    },
+  },
+  verifyGoogleToken: {
+    default: verifyGoogleToken,
+  },
+  generateOAuthUsername: {
+    default: generateOAuthUsername,
+  },
+  makeJobId: {
+    makeUniqueJobId,
+  },
+  renderTemplate: {
+    verificationHtml,
+    resetPasswordHtml,
+  },
+  publishSocketDisconnect: {
+    default: publishSocketDisconnect,
+  },
+  deleteSingleImageService: {
+    default: deleteSingleImageService,
+  },
+  buildDeletedUserData: {
+    default: buildDeletedUserData,
+  },
+  unverifiedAccountCleanup: {
+    cleanupExpiredUnverifiedUserById,
+    isExpiredUnverifiedLocalUser,
+  },
+  clearCacheUtil: {
+    clearNotificationCache,
+  },
+  notificationModel: {
+    default: {
+      deleteMany: notificationDeleteMany,
+    },
+  },
+  userInterestModel: {
+    default: {
+      deleteMany: userInterestDeleteMany,
+    },
+  },
+};
+
+export const mockAuthUnitTestEnvironment = {
+  redisStore,
+  bcryptCompareResults,
+  prismaUserFindFirst,
+  prismaUserFindUnique,
+  prismaUserFindMany,
+  prismaUserCreate,
+  prismaUserUpdate,
+  prismaUserDeleteMany,
+  prismaUserDelete,
+  prismaTransaction,
+  prismaFindUniqueByUsername,
+  prismaDeleteManyGeneric,
+  prismaDeleteManyNotificationSettings,
+  prismaDeleteManyModerationStats,
+  prismaDeleteManyBan,
+  prismaDeleteManyWarning,
+  prismaDeleteManyModerationStrike,
+  prismaDeleteManyAchievement,
+  redisGet,
+  redisSet,
+  redisDel,
+  redisScan,
+  redisMulti,
+  redisMultiChain,
+  bcryptHash,
+  bcryptCompare,
+  emailQueueAdd,
+  verifyGoogleToken,
+  generateOAuthUsername,
+  makeUniqueJobId,
+  verificationHtml,
+  resetPasswordHtml,
+  publishSocketDisconnect,
+  deleteSingleImageService,
+  buildDeletedUserData,
+  clearNotificationCache,
+  cleanupExpiredUnverifiedUserById,
+  isExpiredUnverifiedLocalUser,
+  notificationDeleteMany,
+  userInterestDeleteMany,
+};
+
+export const resetAuthUnitTestEnvironment = () => {
+  redisStore.clear();
+  bcryptCompareResults.clear();
+
+  prismaUserFindFirst.mockReset();
+  prismaUserFindUnique.mockReset();
+  prismaUserFindMany.mockReset();
+  prismaUserCreate.mockReset();
+  prismaUserUpdate.mockReset();
+  prismaUserDeleteMany.mockReset();
+  prismaUserDelete.mockReset();
+  prismaTransaction.mockClear();
+  prismaFindUniqueByUsername.mockClear();
+  prismaDeleteManyGeneric.mockClear();
+  prismaDeleteManyNotificationSettings.mockClear();
+  prismaDeleteManyModerationStats.mockClear();
+  prismaDeleteManyBan.mockClear();
+  prismaDeleteManyWarning.mockClear();
+  prismaDeleteManyModerationStrike.mockClear();
+  prismaDeleteManyAchievement.mockClear();
+
+  redisGet
+    .mockReset()
+    .mockImplementation(async (key: string) => redisStore.get(key) ?? null);
+  redisSet
+    .mockReset()
+    .mockImplementation(async (key: string, value: string) => {
+      redisStore.set(key, value);
+      return "OK";
+    });
+  redisDel.mockReset().mockImplementation(async (...keys: string[]) => {
+    keys.forEach((key) => redisStore.delete(key));
+    return keys.length;
+  });
+  redisScan.mockReset().mockImplementation(async () => ["0", []] as const);
+  redisMulti.mockReset().mockImplementation(() => redisMultiChain);
+  redisMultiChain.incr.mockClear();
+  redisMultiChain.expire.mockClear();
+  redisMultiChain.exec.mockClear();
+
+  bcryptHash.mockClear();
+  bcryptCompare.mockClear();
+
+  emailQueueAdd.mockClear();
+  verifyGoogleToken.mockReset();
+  generateOAuthUsername.mockReset();
+  makeUniqueJobId.mockReset();
+  verificationHtml.mockReset();
+  resetPasswordHtml.mockReset();
+  publishSocketDisconnect.mockClear();
+  deleteSingleImageService.mockClear();
+  buildDeletedUserData.mockClear();
+  clearNotificationCache.mockClear();
+  cleanupExpiredUnverifiedUserById.mockClear();
+  isExpiredUnverifiedLocalUser.mockClear();
+  notificationDeleteMany.mockClear();
+  userInterestDeleteMany.mockClear();
+};
+
+export const seedRedisValue = (key: string, value: unknown) => {
+  redisStore.set(key, JSON.stringify(value));
+};
+
+export const seedBcryptCompareResult = (
+  plain: string,
+  hashed: string,
+  result: boolean,
+) => {
+  bcryptCompareResults.set(`${plain}::${hashed}`, result);
+};

--- a/tests/helpers/mockAuthWorkerTestEnvironment.ts
+++ b/tests/helpers/mockAuthWorkerTestEnvironment.ts
@@ -1,0 +1,106 @@
+import { vi } from "vitest";
+
+type MockWorkerInstance = {
+  name: string;
+  processor: (job: { id?: string; name: string; data?: unknown }) => Promise<unknown>;
+  options: Record<string, unknown>;
+  on: ReturnType<typeof vi.fn>;
+  events: Map<string, (...args: unknown[]) => unknown>;
+};
+
+const workerInstances: MockWorkerInstance[] = [];
+
+const redisMessagingClientConnection = {
+  host: "redis-messaging-test",
+  port: 6379,
+};
+
+const cleanupAllExpiredUnverifiedUsers = vi.fn(async () => 0);
+const deleteAccount = vi.fn(async () => undefined);
+const connectMongoDB = vi.fn(async () => undefined);
+const unverifiedAccountCleanupQueueAdd = vi.fn(async () => ({ id: "job-id" }));
+
+const buildWorkerInstance = (
+  name: string,
+  processor: MockWorkerInstance["processor"],
+  options: Record<string, unknown>,
+) => {
+  const events = new Map<string, (...args: unknown[]) => unknown>();
+  const instance: MockWorkerInstance = {
+    name,
+    processor,
+    options,
+    events,
+    on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+      events.set(event, handler);
+      return instance;
+    }),
+  };
+
+  workerInstances.push(instance);
+  return instance;
+};
+
+function workerConstructorImpl(
+  this: unknown,
+  name: string,
+  processor: MockWorkerInstance["processor"],
+  options: Record<string, unknown>,
+) {
+  return buildWorkerInstance(name, processor, options);
+}
+
+const workerConstructor = vi.fn(workerConstructorImpl);
+
+export const mockAuthWorkerModules = {
+  bullmq: {
+    Worker: workerConstructor,
+  },
+  redisConfig: {
+    redisMessagingClientConnection,
+  },
+  unverifiedAccountCleanupQueue: {
+    default: {
+      add: unverifiedAccountCleanupQueueAdd,
+    },
+  },
+  unverifiedAccountCleanupService: {
+    cleanupAllExpiredUnverifiedUsers,
+  },
+  mongodbConfig: {
+    default: connectMongoDB,
+  },
+  deleteAccountService: {
+    default: deleteAccount,
+  },
+};
+
+export const mockAuthWorkerTestEnvironment = {
+  workerInstances,
+  workerConstructor,
+  redisMessagingClientConnection,
+  cleanupAllExpiredUnverifiedUsers,
+  deleteAccount,
+  connectMongoDB,
+  unverifiedAccountCleanupQueueAdd,
+};
+
+export const resetAuthWorkerTestEnvironment = () => {
+  workerInstances.splice(0, workerInstances.length);
+
+  workerConstructor.mockReset().mockImplementation(
+    function workerConstructorResetImpl(
+      this: unknown,
+      name: string,
+      processor: MockWorkerInstance["processor"],
+      options: Record<string, unknown>,
+    ) {
+      return buildWorkerInstance(name, processor, options);
+    },
+  );
+
+  cleanupAllExpiredUnverifiedUsers.mockReset().mockResolvedValue(0);
+  deleteAccount.mockReset().mockResolvedValue(undefined);
+  connectMongoDB.mockReset().mockResolvedValue(undefined);
+  unverifiedAccountCleanupQueueAdd.mockReset().mockResolvedValue({ id: "job-id" });
+};

--- a/tests/helpers/mockEmailWorkerTestEnvironment.ts
+++ b/tests/helpers/mockEmailWorkerTestEnvironment.ts
@@ -1,0 +1,104 @@
+import { vi } from "vitest";
+
+type MockWorkerInstance = {
+  name: string;
+  processor: (job: { id?: string; name: string; data?: unknown }) => Promise<unknown>;
+  options: Record<string, unknown>;
+  on: ReturnType<typeof vi.fn>;
+  events: Map<string, (...args: unknown[]) => unknown>;
+};
+
+const workerInstances: MockWorkerInstance[] = [];
+
+const redisMessagingClientConnection = {
+  host: "redis-messaging-test",
+  port: 6379,
+};
+
+const prismaUserFindUnique = vi.fn();
+const sendMail = vi.fn(async () => ({ accepted: ["test@example.com"] }));
+const isExpiredUnverifiedLocalUser = vi.fn(() => false);
+
+const buildWorkerInstance = (
+  name: string,
+  processor: MockWorkerInstance["processor"],
+  options: Record<string, unknown>,
+) => {
+  const events = new Map<string, (...args: unknown[]) => unknown>();
+  const instance: MockWorkerInstance = {
+    name,
+    processor,
+    options,
+    events,
+    on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+      events.set(event, handler);
+      return instance;
+    }),
+  };
+
+  workerInstances.push(instance);
+  return instance;
+};
+
+function workerConstructorImpl(
+  this: unknown,
+  name: string,
+  processor: MockWorkerInstance["processor"],
+  options: Record<string, unknown>,
+) {
+  return buildWorkerInstance(name, processor, options);
+}
+
+const workerConstructor = vi.fn(workerConstructorImpl);
+
+export const mockEmailWorkerModules = {
+  bullmq: {
+    Worker: workerConstructor,
+  },
+  redisConfig: {
+    redisMessagingClientConnection,
+  },
+  prismaConfig: {
+    default: {
+      user: {
+        findUnique: prismaUserFindUnique,
+      },
+    },
+  },
+  nodemailerConfig: {
+    default: {
+      sendMail,
+    },
+  },
+  unverifiedAccountCleanupService: {
+    isExpiredUnverifiedLocalUser,
+  },
+};
+
+export const mockEmailWorkerTestEnvironment = {
+  workerInstances,
+  workerConstructor,
+  redisMessagingClientConnection,
+  prismaUserFindUnique,
+  sendMail,
+  isExpiredUnverifiedLocalUser,
+};
+
+export const resetEmailWorkerTestEnvironment = () => {
+  workerInstances.splice(0, workerInstances.length);
+
+  workerConstructor.mockReset().mockImplementation(
+    function workerConstructorResetImpl(
+      this: unknown,
+      name: string,
+      processor: MockWorkerInstance["processor"],
+      options: Record<string, unknown>,
+    ) {
+      return buildWorkerInstance(name, processor, options);
+    },
+  );
+
+  prismaUserFindUnique.mockReset();
+  sendMail.mockReset().mockResolvedValue({ accepted: ["test@example.com"] });
+  isExpiredUnverifiedLocalUser.mockReset().mockReturnValue(false);
+};

--- a/tests/helpers/mockGetDeviceInfo.ts
+++ b/tests/helpers/mockGetDeviceInfo.ts
@@ -1,0 +1,11 @@
+export const defaultMockDeviceInfo = {
+  browser: "Chrome",
+  os: "Linux",
+  ip: "127.0.0.1",
+};
+
+export const createMockGetDeviceInfoModule = (
+  deviceInfo = defaultMockDeviceInfo,
+) => ({
+  default: () => deviceInfo,
+});

--- a/tests/helpers/mockSocketAuthEnvironment.ts
+++ b/tests/helpers/mockSocketAuthEnvironment.ts
@@ -1,0 +1,54 @@
+import { vi } from "vitest";
+
+const initSocketEmitSubscriber = vi.fn();
+const initSocketDisconnectSubscriber = vi.fn();
+const initEditSessionListener = vi.fn();
+const initAiAnswerSessionListener = vi.fn();
+const initQuestionSessionListener = vi.fn();
+
+const initializeSocketUserSession = vi.fn(async () => undefined);
+const removeUserSocket = vi.fn(async () => 1);
+
+export const mockSocketAuthModules = {
+  socketEmitSubscriber: {
+    default: initSocketEmitSubscriber,
+  },
+  socketDisconnectSubscriber: {
+    default: initSocketDisconnectSubscriber,
+  },
+  editSessionListener: {
+    default: initEditSessionListener,
+  },
+  aiAnswerSessionListener: {
+    default: initAiAnswerSessionListener,
+  },
+  questionSessionListener: {
+    default: initQuestionSessionListener,
+  },
+  initializeSocketUserSession: {
+    default: initializeSocketUserSession,
+  },
+  presenceService: {
+    removeUserSocket,
+  },
+};
+
+export const resetSocketAuthEnvironment = () => {
+  initSocketEmitSubscriber.mockClear();
+  initSocketDisconnectSubscriber.mockClear();
+  initEditSessionListener.mockClear();
+  initAiAnswerSessionListener.mockClear();
+  initQuestionSessionListener.mockClear();
+  initializeSocketUserSession.mockClear();
+  removeUserSocket.mockClear();
+};
+
+export {
+  initAiAnswerSessionListener,
+  initEditSessionListener,
+  initQuestionSessionListener,
+  initSocketDisconnectSubscriber,
+  initSocketEmitSubscriber,
+  initializeSocketUserSession,
+  removeUserSocket,
+};

--- a/tests/integration/graphql/auth/graphqlAuth.int.test.ts
+++ b/tests/integration/graphql/auth/graphqlAuth.int.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  authMiddlewareEnvironment,
+  mockAuthMiddlewareModules,
+  resetAuthMiddlewareEnvironment,
+  seedJwtPayload,
+  seedRedisAuthUser,
+} from "../../../helpers/mockAuthMiddlewareEnvironment.js";
+import createGraphqlAuthContext from "../../../helpers/createGraphqlAuthContext.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthMiddlewareModules.prismaConfig,
+);
+
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthMiddlewareModules.redisConfig,
+);
+
+vi.mock("jsonwebtoken", () => mockAuthMiddlewareModules.jsonwebtoken);
+
+describe("GraphQL auth context", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    resetAuthMiddlewareEnvironment();
+  });
+
+  it("rejects missing tokens", async () => {
+    await expect(
+      createGraphqlAuthContext({
+        cookies: {},
+      }),
+    ).rejects.toMatchObject({
+      message: "Not authenticated, no token",
+      statusCode: 400,
+    });
+  });
+
+  it("rejects invalid JWTs", async () => {
+    await expect(
+      createGraphqlAuthContext({
+        cookies: { token: "invalid-token" },
+      }),
+    ).rejects.toMatchObject({
+      message: "Not authenticated, token failed",
+      statusCode: 401,
+    });
+  });
+
+  it("loads auth users from prisma and caches them on a miss", async () => {
+    seedJwtPayload("valid-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+
+    const context = await createGraphqlAuthContext({
+      cookies: { token: "valid-token" },
+    });
+
+    expect(context.user).toEqual({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+    expect(context.loaders.userLoader).toBeDefined();
+    expect(
+      authMiddlewareEnvironment.prismaUserFindUnique,
+    ).toHaveBeenCalledTimes(1);
+    expect(authMiddlewareEnvironment.redisStore.get("auth:user:user_1")).toBe(
+      JSON.stringify({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "ACTIVE",
+        isVerified: true,
+        role: "USER",
+        isDeleted: false,
+      }),
+    );
+  });
+
+  it("uses cached auth users without a prisma lookup", async () => {
+    seedJwtPayload("cached-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    seedRedisAuthUser({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "ADMIN",
+      isDeleted: false,
+    });
+
+    const context = await createGraphqlAuthContext({
+      cookies: { token: "cached-token" },
+    });
+
+    expect(context.user).toEqual({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "ADMIN",
+      isDeleted: false,
+    });
+    expect(
+      authMiddlewareEnvironment.prismaUserFindUnique,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing users", async () => {
+    seedJwtPayload("missing-user-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+
+    await expect(
+      createGraphqlAuthContext({
+        cookies: { token: "missing-user-token" },
+      }),
+    ).rejects.toMatchObject({
+      message: "User not found",
+      statusCode: 404,
+    });
+  });
+
+  it("rejects token version mismatches", async () => {
+    seedJwtPayload("stale-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 1,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+
+    await expect(
+      createGraphqlAuthContext({
+        cookies: { token: "stale-token" },
+      }),
+    ).rejects.toMatchObject({
+      message: "User token expired",
+      statusCode: 401,
+    });
+  });
+
+  it("rejects unverified users", async () => {
+    seedJwtPayload("unverified-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: false,
+      role: "USER",
+      isDeleted: false,
+    });
+
+    await expect(
+      createGraphqlAuthContext({
+        cookies: { token: "unverified-token" },
+      }),
+    ).rejects.toMatchObject({
+      message: "User not verified",
+      statusCode: 403,
+    });
+  });
+
+  it("rejects inactive or deleted users", async () => {
+    seedJwtPayload("deleted-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "SUSPENDED",
+      isVerified: true,
+      role: "USER",
+      isDeleted: true,
+    });
+
+    await expect(
+      createGraphqlAuthContext({
+        cookies: { token: "deleted-token" },
+      }),
+    ).rejects.toMatchObject({
+      message: "User not active",
+      statusCode: 403,
+    });
+  });
+});

--- a/tests/integration/http/auth/changePassword.int.test.ts
+++ b/tests/integration/http/auth/changePassword.int.test.ts
@@ -20,8 +20,9 @@ vi.mock("../../../../src/services/auth/auth.service.js", () => ({
   }),
 }));
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>

--- a/tests/integration/http/auth/changePassword.int.test.ts
+++ b/tests/integration/http/auth/changePassword.int.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+const mocks = vi.hoisted(() => ({
+  changePasswordService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    changePassword: mocks.changePasswordService,
+  }),
+}));
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/password/change", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.changePasswordService.mockReset();
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = true;
+    mockAuthContextState.user = {
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    };
+  });
+
+  it("changes the password successfully", async () => {
+    mocks.changePasswordService.mockResolvedValue({
+      user: {
+        id: "user_1",
+        tokenVersion: 1,
+      },
+    });
+
+    const response = await request(app).post("/api/auth/password/change").send({
+      currentPassword: "Password1!",
+      newPassword: "Password2!",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully changed your password",
+    });
+    expect(response.headers["set-cookie"]).toBeDefined();
+    expect(mocks.changePasswordService).toHaveBeenCalledWith({
+      userId: "user_1",
+      currentPassword: "Password1!",
+      newPassword: "Password2!",
+    });
+  });
+
+  it("rejects invalid current passwords", async () => {
+    const error = new Error("Invalid current password") as Error & {
+      statusCode?: number;
+    };
+    error.statusCode = 401;
+    mocks.changePasswordService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/password/change").send({
+      currentPassword: "WrongPassword1!",
+      newPassword: "Password2!",
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe("Invalid current password");
+  });
+
+  it("rejects reusing the same password", async () => {
+    const error = new Error(
+      "New password must be different from the old password",
+    ) as Error & { statusCode?: number };
+    error.statusCode = 400;
+    mocks.changePasswordService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/password/change").send({
+      currentPassword: "Password1!",
+      newPassword: "Password1!",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "New password must be different from the old password",
+    );
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockAuthContextState.authenticated = false;
+    mockAuthContextState.authError = {
+      status: 400,
+      message: "Not authenticated, no token",
+    };
+
+    const response = await request(app).post("/api/auth/password/change").send({
+      currentPassword: "Password1!",
+      newPassword: "Password2!",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Not authenticated, no token");
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/password/change").send({
+      currentPassword: "",
+      newPassword: "123",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.changePasswordService).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/http/auth/login.int.test.ts
+++ b/tests/integration/http/auth/login.int.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import { mockAuthMiddlewares } from "../../../helpers/mockAuthMiddlewares.js";
+
+const mocks = vi.hoisted(() => ({
+  loginService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    login: mocks.loginService,
+  }),
+}));
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  mockAuthMiddlewares,
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/login", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.loginService.mockReset();
+  });
+
+  it("logs in a user and sets the auth cookie", async () => {
+    mocks.loginService.mockResolvedValue({
+      user: {
+        id: "user_1",
+        tokenVersion: 2,
+        username: "testUser",
+        email: "test@example.com",
+        otpExpireAt: null,
+        otpResendAvailableAt: null,
+        isVerified: true,
+      },
+    });
+
+    const response = await request(app).post("/api/auth/login").send({
+      email: "test@example.com",
+      password: "Password1!",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully logged in",
+      user: {
+        username: "testUser",
+        email: "test@example.com",
+        otpExpireAt: null,
+        otpResendAvailableAt: null,
+        isVerified: true,
+      },
+    });
+    expect(response.headers["set-cookie"]).toBeDefined();
+    expect(mocks.loginService).toHaveBeenCalledWith({
+      email: "test@example.com",
+      password: "Password1!",
+    });
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/login").send({
+      email: "not-an-email",
+      password: "123",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.loginService).not.toHaveBeenCalled();
+  });
+
+  it("returns service errors", async () => {
+    const error = new Error("Invalid credentials") as Error & {
+      statusCode?: number;
+    };
+    error.statusCode = 400;
+
+    mocks.loginService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/login").send({
+      email: "test@example.com",
+      password: "Password1!",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Invalid credentials");
+  });
+});

--- a/tests/integration/http/auth/login.int.test.ts
+++ b/tests/integration/http/auth/login.int.test.ts
@@ -16,12 +16,14 @@ vi.mock("../../../../src/services/auth/auth.service.js", () => ({
   }),
 }));
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
-vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
-  mockAuthMiddlewares,
+vi.mock(
+  "../../../../src/middlewares/auth.middleware.js",
+  () => mockAuthMiddlewares,
 );
 
 const app = await createAuthTestApp();

--- a/tests/integration/http/auth/logout.int.test.ts
+++ b/tests/integration/http/auth/logout.int.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  register: vi.fn(),
+  login: vi.fn(),
+  registerOrLogin: vi.fn(),
+  verifyEmail: vi.fn(),
+  resendVerificationEmail: vi.fn(),
+  sendResetPasswordEmail: vi.fn(),
+  resendResetPasswordEmail: vi.fn(),
+  verifyResetPasswordOtp: vi.fn(),
+  resetPassword: vi.fn(),
+  changePassword: vi.fn(),
+  isAuth: vi.fn(),
+}));
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/session", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = true;
+    mockAuthContextState.user = {
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    };
+  });
+
+  it("clears the auth cookie", async () => {
+    const response = await request(app).post("/api/auth/session");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ message: "Logged Out" });
+    expect(response.headers["set-cookie"]).toBeDefined();
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockAuthContextState.authenticated = false;
+    mockAuthContextState.authError = {
+      status: 400,
+      message: "Not authenticated, no token",
+    };
+
+    const response = await request(app).post("/api/auth/session");
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Not authenticated, no token");
+  });
+});

--- a/tests/integration/http/auth/logout.int.test.ts
+++ b/tests/integration/http/auth/logout.int.test.ts
@@ -23,8 +23,9 @@ vi.mock("../../../../src/services/auth/auth.service.js", () => ({
   isAuth: vi.fn(),
 }));
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>

--- a/tests/integration/http/auth/oauth.int.test.ts
+++ b/tests/integration/http/auth/oauth.int.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import { mockAuthMiddlewares } from "../../../helpers/mockAuthMiddlewares.js";
+
+const mocks = vi.hoisted(() => ({
+  registerOrLoginService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    registerOrLogin: mocks.registerOrLoginService,
+  }),
+}));
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  mockAuthMiddlewares,
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/oauth", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.registerOrLoginService.mockReset();
+  });
+
+  it("handles google oauth registration", async () => {
+    mocks.registerOrLoginService.mockResolvedValue({
+      user: {
+        id: "user_1",
+        tokenVersion: 0,
+        username: "googleUser",
+        email: "google@example.com",
+      },
+      action: "registered",
+    });
+
+    const response = await request(app).post("/api/auth/oauth").send({
+      provider: "google",
+      id_token: "google-token",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully registered",
+      user: {
+        username: "googleUser",
+        email: "google@example.com",
+      },
+    });
+    expect(response.headers["set-cookie"]).toBeDefined();
+    expect(mocks.registerOrLoginService).toHaveBeenCalledWith({
+      provider: "google",
+      idToken: "google-token",
+    });
+  });
+
+  it("handles github oauth login", async () => {
+    mocks.registerOrLoginService.mockResolvedValue({
+      user: {
+        id: "user_2",
+        tokenVersion: 0,
+        username: "githubUser",
+        email: "github@example.com",
+      },
+      action: "loggedIn",
+    });
+
+    const response = await request(app).post("/api/auth/oauth").send({
+      provider: "github",
+      access_token: "github-token",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully logged in",
+      user: {
+        username: "githubUser",
+        email: "github@example.com",
+      },
+    });
+    expect(response.headers["set-cookie"]).toBeDefined();
+    expect(mocks.registerOrLoginService).toHaveBeenCalledWith({
+      provider: "github",
+      accessToken: "github-token",
+    });
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/oauth").send({
+      provider: "twitter",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.registerOrLoginService).not.toHaveBeenCalled();
+  });
+
+  it("returns service errors", async () => {
+    const error = new Error("Invalid Github access token") as Error & {
+      statusCode?: number;
+    };
+    error.statusCode = 400;
+
+    mocks.registerOrLoginService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/oauth").send({
+      provider: "github",
+      access_token: "bad-token",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Invalid Github access token");
+  });
+});

--- a/tests/integration/http/auth/oauth.int.test.ts
+++ b/tests/integration/http/auth/oauth.int.test.ts
@@ -16,12 +16,14 @@ vi.mock("../../../../src/services/auth/auth.service.js", () => ({
   }),
 }));
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
-vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
-  mockAuthMiddlewares,
+vi.mock(
+  "../../../../src/middlewares/auth.middleware.js",
+  () => mockAuthMiddlewares,
 );
 
 const app = await createAuthTestApp();

--- a/tests/integration/http/auth/register.int.test.ts
+++ b/tests/integration/http/auth/register.int.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import {
+  createMockGetDeviceInfoModule,
+  defaultMockDeviceInfo,
+} from "../../../helpers/mockGetDeviceInfo.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import { mockAuthMiddlewares } from "../../../helpers/mockAuthMiddlewares.js";
+
+const mocks = vi.hoisted(() => ({
+  registerService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    register: mocks.registerService,
+  }),
+}));
+
+vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
+  createMockGetDeviceInfoModule(defaultMockDeviceInfo),
+);
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  mockAuthMiddlewares,
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/register", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.registerService.mockReset();
+  });
+
+  it("registers a user and sets the auth cookie", async () => {
+    mocks.registerService.mockResolvedValue({
+      user: {
+        id: "user_1",
+        tokenVersion: 0,
+        username: "testUser",
+        email: "test@example.com",
+        isVerified: false,
+      },
+      otpExpireAt: new Date("2026-01-01T00:00:00.000Z"),
+      otpResendAvailableAt: new Date("2026-01-01T00:00:30.000Z"),
+    });
+
+    const response = await request(app).post("/api/auth/register").send({
+      username: "testUser",
+      email: "test@example.com",
+      password: "Password1!",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully registered",
+      user: {
+        username: "testUser",
+        email: "test@example.com",
+        otpExpireAt: "2026-01-01T00:00:00.000Z",
+        otpResendAvailableAt: "2026-01-01T00:00:30.000Z",
+        isVerified: false,
+      },
+    });
+    expect(response.headers["set-cookie"]).toBeDefined();
+    expect(mocks.registerService).toHaveBeenCalledWith({
+      username: "testUser",
+      email: "test@example.com",
+      password: "Password1!",
+      deviceInfo: {
+        browser: "Chrome",
+        os: "Linux",
+        ip: "127.0.0.1",
+      },
+    });
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/register").send({
+      username: "tu",
+      email: "not-an-email",
+      password: "123",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.registerService).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/http/auth/register.int.test.ts
+++ b/tests/integration/http/auth/register.int.test.ts
@@ -24,12 +24,14 @@ vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
   createMockGetDeviceInfoModule(defaultMockDeviceInfo),
 );
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
-vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
-  mockAuthMiddlewares,
+vi.mock(
+  "../../../../src/middlewares/auth.middleware.js",
+  () => mockAuthMiddlewares,
 );
 
 const app = await createAuthTestApp();

--- a/tests/integration/http/auth/resendResetPasswordEmail.int.test.ts
+++ b/tests/integration/http/auth/resendResetPasswordEmail.int.test.ts
@@ -25,8 +25,9 @@ vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
   createMockGetDeviceInfoModule(),
 );
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
@@ -46,9 +47,11 @@ describe("POST /api/auth/password/reset/resend", () => {
   it("resends the reset password email successfully", async () => {
     mocks.resendResetPasswordEmailService.mockResolvedValue({ sent: true });
 
-    const response = await request(app).post("/api/auth/password/reset/resend").send({
-      email: "test@example.com",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/resend")
+      .send({
+        email: "test@example.com",
+      });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -65,9 +68,11 @@ describe("POST /api/auth/password/reset/resend", () => {
   });
 
   it("rejects invalid payloads", async () => {
-    const response = await request(app).post("/api/auth/password/reset/resend").send({
-      email: "bad-email",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/resend")
+      .send({
+        email: "bad-email",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe("Validation Failed");
@@ -75,15 +80,19 @@ describe("POST /api/auth/password/reset/resend", () => {
   });
 
   it("returns service errors", async () => {
-    const error = new Error("OTP resend will soon be available, please wait") as Error & {
+    const error = new Error(
+      "OTP resend will soon be available, please wait",
+    ) as Error & {
       statusCode?: number;
     };
     error.statusCode = 400;
     mocks.resendResetPasswordEmailService.mockRejectedValue(error);
 
-    const response = await request(app).post("/api/auth/password/reset/resend").send({
-      email: "test@example.com",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/resend")
+      .send({
+        email: "test@example.com",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe(
@@ -94,9 +103,11 @@ describe("POST /api/auth/password/reset/resend", () => {
   it("rejects authenticated requests", async () => {
     mockAuthContextState.authenticated = true;
 
-    const response = await request(app).post("/api/auth/password/reset/resend").send({
-      email: "test@example.com",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/resend")
+      .send({
+        email: "test@example.com",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe(

--- a/tests/integration/http/auth/resendResetPasswordEmail.int.test.ts
+++ b/tests/integration/http/auth/resendResetPasswordEmail.int.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { createMockGetDeviceInfoModule } from "../../../helpers/mockGetDeviceInfo.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+const mocks = vi.hoisted(() => ({
+  resendResetPasswordEmailService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    resendResetPasswordEmail: mocks.resendResetPasswordEmailService,
+  }),
+}));
+
+vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
+  createMockGetDeviceInfoModule(),
+);
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/password/reset/resend", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.resendResetPasswordEmailService.mockReset();
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = false;
+  });
+
+  it("resends the reset password email successfully", async () => {
+    mocks.resendResetPasswordEmailService.mockResolvedValue({ sent: true });
+
+    const response = await request(app).post("/api/auth/password/reset/resend").send({
+      email: "test@example.com",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully sent reset password OTP",
+    });
+    expect(mocks.resendResetPasswordEmailService).toHaveBeenCalledWith({
+      email: "test@example.com",
+      deviceInfo: {
+        browser: "Chrome",
+        os: "Linux",
+        ip: "127.0.0.1",
+      },
+    });
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/password/reset/resend").send({
+      email: "bad-email",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.resendResetPasswordEmailService).not.toHaveBeenCalled();
+  });
+
+  it("returns service errors", async () => {
+    const error = new Error("OTP resend will soon be available, please wait") as Error & {
+      statusCode?: number;
+    };
+    error.statusCode = 400;
+    mocks.resendResetPasswordEmailService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/password/reset/resend").send({
+      email: "test@example.com",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "OTP resend will soon be available, please wait",
+    );
+  });
+
+  it("rejects authenticated requests", async () => {
+    mockAuthContextState.authenticated = true;
+
+    const response = await request(app).post("/api/auth/password/reset/resend").send({
+      email: "test@example.com",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "This action is only available when logged out",
+    );
+  });
+});

--- a/tests/integration/http/auth/resendVerificationEmail.int.test.ts
+++ b/tests/integration/http/auth/resendVerificationEmail.int.test.ts
@@ -25,8 +25,9 @@ vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
   createMockGetDeviceInfoModule(),
 );
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>

--- a/tests/integration/http/auth/resendVerificationEmail.int.test.ts
+++ b/tests/integration/http/auth/resendVerificationEmail.int.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { createMockGetDeviceInfoModule } from "../../../helpers/mockGetDeviceInfo.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+const mocks = vi.hoisted(() => ({
+  resendVerificationEmailService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    resendVerificationEmail: mocks.resendVerificationEmailService,
+  }),
+}));
+
+vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
+  createMockGetDeviceInfoModule(),
+);
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/email/resend", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.resendVerificationEmailService.mockReset();
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = true;
+    mockAuthContextState.user = {
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: false,
+      role: "USER",
+      isDeleted: false,
+    };
+  });
+
+  it("resends the verification email successfully", async () => {
+    mocks.resendVerificationEmailService.mockResolvedValue({
+      user: { id: "user_1" },
+    });
+
+    const response = await request(app).post("/api/auth/email/resend").send({});
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully sent another OTP to your email address",
+    });
+    expect(mocks.resendVerificationEmailService).toHaveBeenCalledWith({
+      userId: "user_1",
+      deviceInfo: {
+        browser: "Chrome",
+        os: "Linux",
+        ip: "127.0.0.1",
+      },
+    });
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockAuthContextState.authenticated = false;
+    mockAuthContextState.authError = {
+      status: 400,
+      message: "Not authenticated, no token",
+    };
+
+    const response = await request(app).post("/api/auth/email/resend").send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Not authenticated, no token");
+  });
+
+  it("returns service errors", async () => {
+    const error = new Error("User already verified") as Error & {
+      statusCode?: number;
+    };
+    error.statusCode = 400;
+    mocks.resendVerificationEmailService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/email/resend").send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("User already verified");
+  });
+});

--- a/tests/integration/http/auth/resetPassword.int.test.ts
+++ b/tests/integration/http/auth/resetPassword.int.test.ts
@@ -20,8 +20,9 @@ vi.mock("../../../../src/services/auth/auth.service.js", () => ({
   }),
 }));
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>

--- a/tests/integration/http/auth/resetPassword.int.test.ts
+++ b/tests/integration/http/auth/resetPassword.int.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+const mocks = vi.hoisted(() => ({
+  resetPasswordService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    resetPassword: mocks.resetPasswordService,
+  }),
+}));
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/password/reset", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.resetPasswordService.mockReset();
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = false;
+  });
+
+  it("resets the password successfully", async () => {
+    mocks.resetPasswordService.mockResolvedValue({
+      user: { id: "user_1" },
+    });
+
+    const response = await request(app).post("/api/auth/password/reset").send({
+      email: "test@example.com",
+      newPassword: "Password2!",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully updated your password",
+    });
+    expect(mocks.resetPasswordService).toHaveBeenCalledWith({
+      email: "test@example.com",
+      newPassword: "Password2!",
+    });
+  });
+
+  it("rejects the same password", async () => {
+    const error = new Error(
+      "New password must be different from the old password",
+    ) as Error & { statusCode?: number };
+    error.statusCode = 400;
+    mocks.resetPasswordService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/password/reset").send({
+      email: "test@example.com",
+      newPassword: "Password1!",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "New password must be different from the old password",
+    );
+  });
+
+  it("rejects when otp was not verified", async () => {
+    const error = new Error("OTP not verified") as Error & {
+      statusCode?: number;
+    };
+    error.statusCode = 400;
+    mocks.resetPasswordService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/password/reset").send({
+      email: "test@example.com",
+      newPassword: "Password2!",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("OTP not verified");
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/password/reset").send({
+      email: "bad-email",
+      newPassword: "123",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.resetPasswordService).not.toHaveBeenCalled();
+  });
+
+  it("rejects authenticated requests", async () => {
+    mockAuthContextState.authenticated = true;
+
+    const response = await request(app).post("/api/auth/password/reset").send({
+      email: "test@example.com",
+      newPassword: "Password2!",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "This action is only available when logged out",
+    );
+  });
+});

--- a/tests/integration/http/auth/sendResetPasswordEmail.int.test.ts
+++ b/tests/integration/http/auth/sendResetPasswordEmail.int.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { createMockGetDeviceInfoModule } from "../../../helpers/mockGetDeviceInfo.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+const mocks = vi.hoisted(() => ({
+  sendResetPasswordEmailService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    sendResetPasswordEmail: mocks.sendResetPasswordEmailService,
+  }),
+}));
+
+vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
+  createMockGetDeviceInfoModule(),
+);
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/password/reset/send", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.sendResetPasswordEmailService.mockReset();
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = false;
+  });
+
+  it("sends reset password email for existing accounts", async () => {
+    mocks.sendResetPasswordEmailService.mockResolvedValue({ sent: true });
+
+    const response = await request(app).post("/api/auth/password/reset/send").send({
+      email: "test@example.com",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "If account exists, an email was sent",
+    });
+    expect(mocks.sendResetPasswordEmailService).toHaveBeenCalledWith({
+      email: "test@example.com",
+      deviceInfo: {
+        browser: "Chrome",
+        os: "Linux",
+        ip: "127.0.0.1",
+      },
+    });
+  });
+
+  it("also responds safely when the account does not exist", async () => {
+    mocks.sendResetPasswordEmailService.mockResolvedValue({ sent: true });
+
+    const response = await request(app).post("/api/auth/password/reset/send").send({
+      email: "missing@example.com",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "If account exists, an email was sent",
+    });
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/password/reset/send").send({
+      email: "bad-email",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.sendResetPasswordEmailService).not.toHaveBeenCalled();
+  });
+
+  it("rejects authenticated requests", async () => {
+    mockAuthContextState.authenticated = true;
+
+    const response = await request(app).post("/api/auth/password/reset/send").send({
+      email: "test@example.com",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "This action is only available when logged out",
+    );
+  });
+});

--- a/tests/integration/http/auth/sendResetPasswordEmail.int.test.ts
+++ b/tests/integration/http/auth/sendResetPasswordEmail.int.test.ts
@@ -25,8 +25,9 @@ vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
   createMockGetDeviceInfoModule(),
 );
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
@@ -46,9 +47,11 @@ describe("POST /api/auth/password/reset/send", () => {
   it("sends reset password email for existing accounts", async () => {
     mocks.sendResetPasswordEmailService.mockResolvedValue({ sent: true });
 
-    const response = await request(app).post("/api/auth/password/reset/send").send({
-      email: "test@example.com",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/send")
+      .send({
+        email: "test@example.com",
+      });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -67,9 +70,11 @@ describe("POST /api/auth/password/reset/send", () => {
   it("also responds safely when the account does not exist", async () => {
     mocks.sendResetPasswordEmailService.mockResolvedValue({ sent: true });
 
-    const response = await request(app).post("/api/auth/password/reset/send").send({
-      email: "missing@example.com",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/send")
+      .send({
+        email: "missing@example.com",
+      });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -78,9 +83,11 @@ describe("POST /api/auth/password/reset/send", () => {
   });
 
   it("rejects invalid payloads", async () => {
-    const response = await request(app).post("/api/auth/password/reset/send").send({
-      email: "bad-email",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/send")
+      .send({
+        email: "bad-email",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe("Validation Failed");
@@ -90,9 +97,11 @@ describe("POST /api/auth/password/reset/send", () => {
   it("rejects authenticated requests", async () => {
     mockAuthContextState.authenticated = true;
 
-    const response = await request(app).post("/api/auth/password/reset/send").send({
-      email: "test@example.com",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/send")
+      .send({
+        email: "test@example.com",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe(

--- a/tests/integration/http/auth/session.int.test.ts
+++ b/tests/integration/http/auth/session.int.test.ts
@@ -20,8 +20,9 @@ vi.mock("../../../../src/services/auth/auth.service.js", () => ({
   }),
 }));
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>

--- a/tests/integration/http/auth/session.int.test.ts
+++ b/tests/integration/http/auth/session.int.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+const mocks = vi.hoisted(() => ({
+  isAuthService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    isAuth: mocks.isAuthService,
+  }),
+}));
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("GET /api/auth/session", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.isAuthService.mockReset();
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = true;
+    mockAuthContextState.user = {
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    };
+  });
+
+  it("returns the authenticated user", async () => {
+    mocks.isAuthService.mockResolvedValue({
+      user: {
+        id: "user_1",
+        username: "testUser",
+        email: "test@example.com",
+        isVerified: true,
+      },
+    });
+
+    const response = await request(app).get("/api/auth/session");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully authenticated",
+      user: {
+        id: "user_1",
+        username: "testUser",
+        email: "test@example.com",
+        isVerified: true,
+      },
+    });
+    expect(mocks.isAuthService).toHaveBeenCalledWith({
+      userId: "user_1",
+    });
+  });
+
+  it("rejects missing token", async () => {
+    mockAuthContextState.authenticated = false;
+    mockAuthContextState.authError = {
+      status: 400,
+      message: "Not authenticated, no token",
+    };
+
+    const response = await request(app).get("/api/auth/session");
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Not authenticated, no token");
+  });
+
+  it("rejects invalid token", async () => {
+    mockAuthContextState.authenticated = false;
+    mockAuthContextState.authError = {
+      status: 401,
+      message: "Not authenticated, token failed",
+    };
+
+    const response = await request(app).get("/api/auth/session");
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe("Not authenticated, token failed");
+  });
+
+  it("rejects expired tokens", async () => {
+    mockAuthContextState.authenticated = false;
+    mockAuthContextState.authError = {
+      status: 401,
+      message: "User token expired",
+    };
+
+    const response = await request(app).get("/api/auth/session");
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe("User token expired");
+  });
+
+  it("rejects deleted users", async () => {
+    mockAuthContextState.user = {
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: true,
+    };
+
+    const response = await request(app).get("/api/auth/session");
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toBe("User not active");
+  });
+});

--- a/tests/integration/http/auth/verifyEmail.int.test.ts
+++ b/tests/integration/http/auth/verifyEmail.int.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { createMockGetDeviceInfoModule } from "../../../helpers/mockGetDeviceInfo.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+const mocks = vi.hoisted(() => ({
+  verifyEmailService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    verifyEmail: mocks.verifyEmailService,
+  }),
+}));
+
+vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
+  createMockGetDeviceInfoModule(),
+);
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/email/verify", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.verifyEmailService.mockReset();
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = true;
+    mockAuthContextState.user = {
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: false,
+      role: "USER",
+      isDeleted: false,
+    };
+  });
+
+  it("verifies the email successfully", async () => {
+    mocks.verifyEmailService.mockResolvedValue({
+      user: {
+        id: "user_1",
+        username: "testUser",
+        email: "test@example.com",
+        isVerified: true,
+      },
+    });
+
+    const response = await request(app).post("/api/auth/email/verify").send({
+      otp: "123456",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully verified",
+      user: {
+        username: "testUser",
+        email: "test@example.com",
+        isVerified: true,
+      },
+    });
+    expect(mocks.verifyEmailService).toHaveBeenCalledWith({
+      userId: "user_1",
+      otp: "123456",
+    });
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/email/verify").send({
+      otp: "123",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.verifyEmailService).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockAuthContextState.authenticated = false;
+    mockAuthContextState.authError = {
+      status: 400,
+      message: "Not authenticated, no token",
+    };
+
+    const response = await request(app).post("/api/auth/email/verify").send({
+      otp: "123456",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Not authenticated, no token");
+  });
+
+  it("returns service errors", async () => {
+    const error = new Error("Invalid OTP") as Error & { statusCode?: number };
+    error.statusCode = 400;
+    mocks.verifyEmailService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/email/verify").send({
+      otp: "123456",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Invalid OTP");
+  });
+});

--- a/tests/integration/http/auth/verifyEmail.int.test.ts
+++ b/tests/integration/http/auth/verifyEmail.int.test.ts
@@ -25,8 +25,9 @@ vi.mock("../../../../src/utils/getDeviceInfo.util.js", () =>
   createMockGetDeviceInfoModule(),
 );
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>

--- a/tests/integration/http/auth/verifyResetPasswordOtp.int.test.ts
+++ b/tests/integration/http/auth/verifyResetPasswordOtp.int.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import { createAuthTestApp } from "../../../helpers/createTestApp.js";
+import { createAuthServiceModuleMock } from "../../../helpers/createAuthServiceModuleMock.js";
+import { mockAuthLimiters } from "../../../helpers/mockAuthLimiters.js";
+import {
+  createMockAuthMiddlewareModule,
+  mockAuthContextState,
+  resetMockAuthContextState,
+} from "../../../helpers/mockAuthContext.js";
+
+const mocks = vi.hoisted(() => ({
+  verifyResetPasswordOtpService: vi.fn(),
+}));
+
+vi.mock("../../../../src/services/auth/auth.service.js", () => ({
+  ...createAuthServiceModuleMock({
+    verifyResetPasswordOtp: mocks.verifyResetPasswordOtpService,
+  }),
+}));
+
+vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
+  mockAuthLimiters,
+);
+
+vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
+  createMockAuthMiddlewareModule(),
+);
+
+const app = await createAuthTestApp();
+
+describe("POST /api/auth/password/reset/verify", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    mocks.verifyResetPasswordOtpService.mockReset();
+    resetMockAuthContextState();
+    mockAuthContextState.authenticated = false;
+  });
+
+  it("verifies the reset password OTP successfully", async () => {
+    mocks.verifyResetPasswordOtpService.mockResolvedValue({ verified: true });
+
+    const response = await request(app).post("/api/auth/password/reset/verify").send({
+      email: "test@example.com",
+      otp: "123456",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "Successfully verified OTP",
+    });
+    expect(mocks.verifyResetPasswordOtpService).toHaveBeenCalledWith({
+      email: "test@example.com",
+      otp: "123456",
+    });
+  });
+
+  it("rejects invalid payloads", async () => {
+    const response = await request(app).post("/api/auth/password/reset/verify").send({
+      email: "bad-email",
+      otp: "123",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation Failed");
+    expect(mocks.verifyResetPasswordOtpService).not.toHaveBeenCalled();
+  });
+
+  it("returns service errors for invalid otp", async () => {
+    const error = new Error("Invalid reset password OTP") as Error & {
+      statusCode?: number;
+    };
+    error.statusCode = 400;
+    mocks.verifyResetPasswordOtpService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/password/reset/verify").send({
+      email: "test@example.com",
+      otp: "123456",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Invalid reset password OTP");
+  });
+
+  it("returns service errors for expired otp", async () => {
+    const error = new Error("Reset password OTP expired") as Error & {
+      statusCode?: number;
+    };
+    error.statusCode = 400;
+    mocks.verifyResetPasswordOtpService.mockRejectedValue(error);
+
+    const response = await request(app).post("/api/auth/password/reset/verify").send({
+      email: "test@example.com",
+      otp: "123456",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Reset password OTP expired");
+  });
+
+  it("rejects authenticated requests", async () => {
+    mockAuthContextState.authenticated = true;
+
+    const response = await request(app).post("/api/auth/password/reset/verify").send({
+      email: "test@example.com",
+      otp: "123456",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "This action is only available when logged out",
+    );
+  });
+});

--- a/tests/integration/http/auth/verifyResetPasswordOtp.int.test.ts
+++ b/tests/integration/http/auth/verifyResetPasswordOtp.int.test.ts
@@ -20,8 +20,9 @@ vi.mock("../../../../src/services/auth/auth.service.js", () => ({
   }),
 }));
 
-vi.mock("../../../../src/middlewares/rate-limiters/auth.rate-limiters.js", () =>
-  mockAuthLimiters,
+vi.mock(
+  "../../../../src/middlewares/rate-limiters/auth.rate-limiters.js",
+  () => mockAuthLimiters,
 );
 
 vi.mock("../../../../src/middlewares/auth.middleware.js", () =>
@@ -41,10 +42,12 @@ describe("POST /api/auth/password/reset/verify", () => {
   it("verifies the reset password OTP successfully", async () => {
     mocks.verifyResetPasswordOtpService.mockResolvedValue({ verified: true });
 
-    const response = await request(app).post("/api/auth/password/reset/verify").send({
-      email: "test@example.com",
-      otp: "123456",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/verify")
+      .send({
+        email: "test@example.com",
+        otp: "123456",
+      });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -57,10 +60,12 @@ describe("POST /api/auth/password/reset/verify", () => {
   });
 
   it("rejects invalid payloads", async () => {
-    const response = await request(app).post("/api/auth/password/reset/verify").send({
-      email: "bad-email",
-      otp: "123",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/verify")
+      .send({
+        email: "bad-email",
+        otp: "123",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe("Validation Failed");
@@ -74,10 +79,12 @@ describe("POST /api/auth/password/reset/verify", () => {
     error.statusCode = 400;
     mocks.verifyResetPasswordOtpService.mockRejectedValue(error);
 
-    const response = await request(app).post("/api/auth/password/reset/verify").send({
-      email: "test@example.com",
-      otp: "123456",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/verify")
+      .send({
+        email: "test@example.com",
+        otp: "123456",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe("Invalid reset password OTP");
@@ -90,10 +97,12 @@ describe("POST /api/auth/password/reset/verify", () => {
     error.statusCode = 400;
     mocks.verifyResetPasswordOtpService.mockRejectedValue(error);
 
-    const response = await request(app).post("/api/auth/password/reset/verify").send({
-      email: "test@example.com",
-      otp: "123456",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/verify")
+      .send({
+        email: "test@example.com",
+        otp: "123456",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe("Reset password OTP expired");
@@ -102,10 +111,12 @@ describe("POST /api/auth/password/reset/verify", () => {
   it("rejects authenticated requests", async () => {
     mockAuthContextState.authenticated = true;
 
-    const response = await request(app).post("/api/auth/password/reset/verify").send({
-      email: "test@example.com",
-      otp: "123456",
-    });
+    const response = await request(app)
+      .post("/api/auth/password/reset/verify")
+      .send({
+        email: "test@example.com",
+        otp: "123456",
+      });
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe(

--- a/tests/integration/middleware/auth/accessGuards.int.test.ts
+++ b/tests/integration/middleware/auth/accessGuards.int.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import createMiddlewareTestApp from "../../../helpers/createMiddlewareTestApp.js";
+import {
+  authMiddlewareEnvironment,
+  mockAuthMiddlewareModules,
+  resetAuthMiddlewareEnvironment,
+  seedJwtPayload,
+} from "../../../helpers/mockAuthMiddlewareEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthMiddlewareModules.prismaConfig,
+);
+
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthMiddlewareModules.redisConfig,
+);
+
+vi.mock("jsonwebtoken", () => mockAuthMiddlewareModules.jsonwebtoken);
+
+const {
+  requireLoggedOut,
+  isVerified,
+  requireActiveUser,
+  isAdmin,
+  default: isAuthenticated,
+} = await import("../../../../src/middlewares/auth.middleware.js");
+
+describe("auth guards", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    resetAuthMiddlewareEnvironment();
+  });
+
+  describe("requireLoggedOut", () => {
+    const app = createMiddlewareTestApp({
+      middlewares: [requireLoggedOut],
+    });
+
+    it("passes when there is no token", async () => {
+      const response = await request(app).get("/test");
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe("ok");
+    });
+
+    it("rejects when a valid token is present", async () => {
+      seedJwtPayload("valid-token", { userId: "user_1", tokenVersion: 0 });
+      authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "ACTIVE",
+        isVerified: true,
+        role: "USER",
+        isDeleted: false,
+      });
+
+      const response = await request(app)
+        .get("/test")
+        .set("Cookie", ["token=valid-token"]);
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe(
+        "This action is only available when logged out",
+      );
+    });
+  });
+
+  describe("isVerified", () => {
+    const app = createMiddlewareTestApp({
+      middlewares: [isAuthenticated, isVerified],
+    });
+
+    beforeEach(() => {
+      authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "ACTIVE",
+        isVerified: true,
+        role: "USER",
+        isDeleted: false,
+      });
+      seedJwtPayload("verified-token", { userId: "user_1", tokenVersion: 0 });
+    });
+
+    it("passes for verified users", async () => {
+      const response = await request(app)
+        .get("/test")
+        .set("Cookie", ["token=verified-token"]);
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe("ok");
+    });
+
+    it("rejects unverified users", async () => {
+      authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "ACTIVE",
+        isVerified: false,
+        role: "USER",
+        isDeleted: false,
+      });
+
+      const response = await request(app)
+        .get("/test")
+        .set("Cookie", ["token=verified-token"]);
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBe("User not verified");
+    });
+  });
+
+  describe("requireActiveUser", () => {
+    const app = createMiddlewareTestApp({
+      middlewares: [isAuthenticated, requireActiveUser],
+    });
+
+    beforeEach(() => {
+      seedJwtPayload("active-token", { userId: "user_1", tokenVersion: 0 });
+    });
+
+    it("passes for active users", async () => {
+      authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "ACTIVE",
+        isVerified: true,
+        role: "USER",
+        isDeleted: false,
+      });
+
+      const response = await request(app)
+        .get("/test")
+        .set("Cookie", ["token=active-token"]);
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe("ok");
+    });
+
+    it("rejects suspended users", async () => {
+      authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "SUSPENDED",
+        isVerified: true,
+        role: "USER",
+        isDeleted: false,
+      });
+
+      const response = await request(app)
+        .get("/test")
+        .set("Cookie", ["token=active-token"]);
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBe("User not active");
+    });
+  });
+
+  describe("isAdmin", () => {
+    const app = createMiddlewareTestApp({
+      middlewares: [isAuthenticated, isAdmin],
+    });
+
+    beforeEach(() => {
+      seedJwtPayload("admin-token", { userId: "user_1", tokenVersion: 0 });
+    });
+
+    it("passes for admins", async () => {
+      authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "ACTIVE",
+        isVerified: true,
+        role: "ADMIN",
+        isDeleted: false,
+      });
+
+      const response = await request(app)
+        .get("/test")
+        .set("Cookie", ["token=admin-token"]);
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe("ok");
+    });
+
+    it("rejects non-admin users", async () => {
+      authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "ACTIVE",
+        isVerified: true,
+        role: "USER",
+        isDeleted: false,
+      });
+
+      const response = await request(app)
+        .get("/test")
+        .set("Cookie", ["token=admin-token"]);
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBe("User forbidden accessing this route");
+    });
+  });
+});

--- a/tests/integration/middleware/auth/isAuthenticated.int.test.ts
+++ b/tests/integration/middleware/auth/isAuthenticated.int.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+import createMiddlewareTestApp from "../../../helpers/createMiddlewareTestApp.js";
+import AuthenticatedRequest from "../../../../src/types/authenticatedRequest.type.js";
+import {
+  authMiddlewareEnvironment,
+  mockAuthMiddlewareModules,
+  resetAuthMiddlewareEnvironment,
+  seedJwtPayload,
+  seedRedisAuthUser,
+} from "../../../helpers/mockAuthMiddlewareEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthMiddlewareModules.prismaConfig,
+);
+
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthMiddlewareModules.redisConfig,
+);
+
+vi.mock("jsonwebtoken", () => mockAuthMiddlewareModules.jsonwebtoken);
+
+const { default: isAuthenticated } = await import(
+  "../../../../src/middlewares/auth.middleware.js"
+);
+
+const app = createMiddlewareTestApp({
+  middlewares: [isAuthenticated],
+  handler: (req: AuthenticatedRequest, res) => {
+    res.status(200).json({ user: req.user });
+  },
+});
+
+describe("isAuthenticated", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    resetAuthMiddlewareEnvironment();
+  });
+
+  it("rejects missing token", async () => {
+    const response = await request(app).get("/test");
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Not authenticated, no token");
+  });
+
+  it("rejects invalid jwt", async () => {
+    const response = await request(app)
+      .get("/test")
+      .set("Cookie", ["token=invalid-token"]);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe("Not authenticated, token failed");
+  });
+
+  it("rejects missing users", async () => {
+    seedJwtPayload("valid-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+
+    const response = await request(app)
+      .get("/test")
+      .set("Cookie", ["token=valid-token"]);
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("User not found");
+  });
+
+  it("rejects token version mismatch", async () => {
+    seedJwtPayload("valid-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 1,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+
+    const response = await request(app)
+      .get("/test")
+      .set("Cookie", ["token=valid-token"]);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe("User token expired");
+  });
+
+  it("rejects deleted users", async () => {
+    seedJwtPayload("valid-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: true,
+    });
+
+    const response = await request(app)
+      .get("/test")
+      .set("Cookie", ["token=valid-token"]);
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toBe("User not active");
+  });
+
+  it("attaches auth user and caches on miss", async () => {
+    seedJwtPayload("valid-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+
+    const response = await request(app)
+      .get("/test")
+      .set("Cookie", ["token=valid-token"]);
+
+    expect(response.status).toBe(200);
+    expect(response.body.user).toEqual({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+    expect(
+      authMiddlewareEnvironment.prismaUserFindUnique,
+    ).toHaveBeenCalledTimes(1);
+    expect(authMiddlewareEnvironment.redisStore.get("auth:user:user_1")).toBe(
+      JSON.stringify({
+        id: "user_1",
+        tokenVersion: 0,
+        status: "ACTIVE",
+        isVerified: true,
+        role: "USER",
+        isDeleted: false,
+      }),
+    );
+  });
+
+  it("uses cached auth user without prisma lookup", async () => {
+    seedJwtPayload("cached-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    seedRedisAuthUser({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "ADMIN",
+      isDeleted: false,
+    });
+
+    const response = await request(app)
+      .get("/test")
+      .set("Cookie", ["token=cached-token"]);
+
+    expect(response.status).toBe(200);
+    expect(response.body.user).toEqual({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "ADMIN",
+      isDeleted: false,
+    });
+    expect(
+      authMiddlewareEnvironment.prismaUserFindUnique,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/sockets/auth/socketAuth.int.test.ts
+++ b/tests/integration/sockets/auth/socketAuth.int.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  authMiddlewareEnvironment,
+  mockAuthMiddlewareModules,
+  resetAuthMiddlewareEnvironment,
+  seedJwtPayload,
+  seedRedisAuthUser,
+} from "../../../helpers/mockAuthMiddlewareEnvironment.js";
+import {
+  mockSocketAuthModules,
+  resetSocketAuthEnvironment,
+  initializeSocketUserSession,
+  removeUserSocket,
+} from "../../../helpers/mockSocketAuthEnvironment.js";
+import createSocketTestServer from "../../../helpers/createSocketTestServer.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthMiddlewareModules.prismaConfig,
+);
+
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthMiddlewareModules.redisConfig,
+);
+
+vi.mock("jsonwebtoken", () => mockAuthMiddlewareModules.jsonwebtoken);
+
+vi.mock(
+  "../../../../src/sockets/subscribers/socketEmit.subscriber.js",
+  () => mockSocketAuthModules.socketEmitSubscriber,
+);
+
+vi.mock(
+  "../../../../src/sockets/subscribers/socketDisconnect.subscriber.js",
+  () => mockSocketAuthModules.socketDisconnectSubscriber,
+);
+
+vi.mock(
+  "../../../../src/sockets/listeners/editSession.listener.js",
+  () => mockSocketAuthModules.editSessionListener,
+);
+
+vi.mock(
+  "../../../../src/sockets/listeners/aiAnswerSession.listener.js",
+  () => mockSocketAuthModules.aiAnswerSessionListener,
+);
+
+vi.mock(
+  "../../../../src/sockets/listeners/questionSession.listener.js",
+  () => mockSocketAuthModules.questionSessionListener,
+);
+
+vi.mock(
+  "../../../../src/services/socket/initializeSocketUserSession.service.js",
+  () => mockSocketAuthModules.initializeSocketUserSession,
+);
+
+vi.mock(
+  "../../../../src/services/redis/presence.service.js",
+  () => mockSocketAuthModules.presenceService,
+);
+
+describe("Socket auth", () => {
+  let server!: Awaited<ReturnType<typeof createSocketTestServer>>;
+
+  const waitForCondition = async (
+    assertion: () => void,
+    timeoutMs = 3000,
+    intervalMs = 25,
+  ) => {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < timeoutMs) {
+      try {
+        assertion();
+        return;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      }
+    }
+
+    assertion();
+  };
+
+  beforeEach(async () => {
+    process.env.JWT_SECRET = "test-jwt-secret";
+    resetAuthMiddlewareEnvironment();
+    resetSocketAuthEnvironment();
+    server = await createSocketTestServer();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it("rejects missing handshake tokens", async () => {
+    await expect(server.connect()).rejects.toMatchObject({
+      message: "Not authenticated: no token",
+    });
+  });
+
+  it("rejects invalid JWTs", async () => {
+    await expect(server.connect("invalid-token")).rejects.toMatchObject({
+      message: "Authentication failed",
+    });
+  });
+
+  it("loads users from prisma on a cache miss", async () => {
+    seedJwtPayload("valid-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      isDeleted: false,
+    });
+
+    const socket = await server.connect("valid-token");
+
+    expect(socket.connected).toBe(true);
+    expect(initializeSocketUserSession).toHaveBeenCalledWith(
+      "user_1",
+      socket.id,
+    );
+    expect(
+      authMiddlewareEnvironment.prismaUserFindUnique,
+    ).toHaveBeenCalledTimes(1);
+
+    socket.disconnect();
+  });
+
+  it("uses cached users without a prisma lookup", async () => {
+    seedJwtPayload("cached-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    seedRedisAuthUser({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+
+    const socket = await server.connect("cached-token");
+
+    expect(socket.connected).toBe(true);
+    expect(initializeSocketUserSession).toHaveBeenCalledWith(
+      "user_1",
+      socket.id,
+    );
+    expect(
+      authMiddlewareEnvironment.prismaUserFindUnique,
+    ).not.toHaveBeenCalled();
+
+    socket.disconnect();
+  });
+
+  it("rejects missing users", async () => {
+    seedJwtPayload("missing-user-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+
+    await expect(server.connect("missing-user-token")).rejects.toMatchObject({
+      message: "Authentication failed",
+    });
+  });
+
+  it("rejects token version mismatches", async () => {
+    seedJwtPayload("stale-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 1,
+      status: "ACTIVE",
+      isVerified: true,
+      isDeleted: false,
+    });
+
+    await expect(server.connect("stale-token")).rejects.toMatchObject({
+      message: "Authentication failed",
+    });
+  });
+
+  it("rejects unverified users", async () => {
+    seedJwtPayload("unverified-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: false,
+      isDeleted: false,
+    });
+
+    await expect(server.connect("unverified-token")).rejects.toMatchObject({
+      message: "Authentication failed",
+    });
+  });
+
+  it("rejects inactive or deleted users", async () => {
+    seedJwtPayload("deleted-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "SUSPENDED",
+      isVerified: true,
+      isDeleted: true,
+    });
+
+    await expect(server.connect("deleted-token")).rejects.toMatchObject({
+      message: "Authentication failed",
+    });
+  });
+
+  it("disconnects sockets and removes the socket binding", async () => {
+    seedJwtPayload("disconnect-token", {
+      userId: "user_1",
+      tokenVersion: 0,
+    });
+    authMiddlewareEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      isDeleted: false,
+    });
+
+    const socket = await server.connect("disconnect-token");
+    const socketId = socket.id;
+    socket.disconnect();
+
+    await waitForCondition(() => {
+      expect(removeUserSocket).toHaveBeenCalledWith(socketId);
+    });
+  });
+});

--- a/tests/integration/workers/auth/accountDeletion.int.test.ts
+++ b/tests/integration/workers/auth/accountDeletion.int.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthWorkerModules,
+  mockAuthWorkerTestEnvironment,
+  resetAuthWorkerTestEnvironment,
+} from "../../../helpers/mockAuthWorkerTestEnvironment.js";
+
+vi.mock("bullmq", () => mockAuthWorkerModules.bullmq);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthWorkerModules.redisConfig,
+);
+vi.mock(
+  "../../../../src/config/mongodb.config.js",
+  () => mockAuthWorkerModules.mongodbConfig,
+);
+vi.mock(
+  "../../../../src/services/auth/deleteAccount.service.js",
+  () => mockAuthWorkerModules.deleteAccountService,
+);
+
+const { startAccountDeletionWorker } = await import(
+  "../../../../src/workers/accountDeletion.worker.js"
+);
+
+describe("accountDeletion worker", () => {
+  const consoleLogSpy = vi
+    .spyOn(console, "log")
+    .mockImplementation(() => undefined);
+  const consoleErrorSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => undefined);
+  const originalMongoUri = process.env.MONGO_URI;
+
+  beforeEach(() => {
+    resetAuthWorkerTestEnvironment();
+    process.env.MONGO_URI = "mongodb://localhost:27017/test";
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+  });
+
+  afterEach(() => {
+    process.env.MONGO_URI = originalMongoUri;
+    vi.clearAllMocks();
+  });
+
+  it("connects Mongo before creating the worker", async () => {
+    await startAccountDeletionWorker();
+
+    expect(mockAuthWorkerTestEnvironment.connectMongoDB).toHaveBeenCalledWith(
+      "mongodb://localhost:27017/test",
+    );
+    expect(mockAuthWorkerTestEnvironment.workerInstances).toHaveLength(1);
+    expect(
+      mockAuthWorkerTestEnvironment.connectMongoDB.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mockAuthWorkerTestEnvironment.workerConstructor.mock
+        .invocationCallOrder[0],
+    );
+  });
+
+  it("creates the worker with the expected queue config", async () => {
+    await startAccountDeletionWorker();
+
+    const worker = mockAuthWorkerTestEnvironment.workerInstances[0];
+
+    expect(worker.name).toBe("accountDeletionQueue");
+    expect(worker.options).toMatchObject({
+      connection: mockAuthWorkerTestEnvironment.redisMessagingClientConnection,
+      concurrency: 1,
+      limiter: {
+        max: 5,
+        duration: 5000,
+      },
+    });
+    expect(worker.events.has("completed")).toBe(true);
+    expect(worker.events.has("failed")).toBe(true);
+    expect(worker.events.has("error")).toBe(true);
+  });
+
+  it("passes job data through to deleteAccount", async () => {
+    await startAccountDeletionWorker();
+
+    const worker = mockAuthWorkerTestEnvironment.workerInstances[0];
+    const result = await worker.processor({
+      name: "DELETE_ACCOUNT",
+      id: "job-1",
+      data: {
+        userId: "user_1",
+        profilePictureKey: "profile-key",
+      },
+    });
+
+    expect(result).toBeUndefined();
+    expect(mockAuthWorkerTestEnvironment.deleteAccount).toHaveBeenCalledWith({
+      userId: "user_1",
+      profilePictureKey: "profile-key",
+    });
+  });
+
+  it("rejects cleanly when Mongo connection fails", async () => {
+    mockAuthWorkerTestEnvironment.connectMongoDB.mockRejectedValueOnce(
+      new Error("mongo down"),
+    );
+
+    await expect(startAccountDeletionWorker()).rejects.toThrow("mongo down");
+    expect(mockAuthWorkerTestEnvironment.workerInstances).toHaveLength(0);
+  });
+
+  it("rejects cleanly when worker construction fails", async () => {
+    mockAuthWorkerTestEnvironment.workerConstructor.mockImplementationOnce(
+      () => {
+        throw new Error("worker failed");
+      },
+    );
+
+    await expect(startAccountDeletionWorker()).rejects.toThrow("worker failed");
+  });
+});

--- a/tests/integration/workers/auth/unverifiedAccountCleanup.int.test.ts
+++ b/tests/integration/workers/auth/unverifiedAccountCleanup.int.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthWorkerModules,
+  mockAuthWorkerTestEnvironment,
+  resetAuthWorkerTestEnvironment,
+} from "../../../helpers/mockAuthWorkerTestEnvironment.js";
+
+vi.mock("bullmq", () => mockAuthWorkerModules.bullmq);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthWorkerModules.redisConfig,
+);
+vi.mock(
+  "../../../../src/queues/unverifiedAccountCleanup.queue.js",
+  () => mockAuthWorkerModules.unverifiedAccountCleanupQueue,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthWorkerModules.unverifiedAccountCleanupService,
+);
+
+const {
+  CLEANUP_JOB_NAME,
+  CLEANUP_REPEAT_EVERY_MS,
+  startUnverifiedAccountCleanupWorker,
+} = await import("../../../../src/workers/unverifiedAccountCleanup.worker.js");
+
+describe("unverifiedAccountCleanup worker", () => {
+  const consoleLogSpy = vi
+    .spyOn(console, "log")
+    .mockImplementation(() => undefined);
+  const consoleErrorSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    resetAuthWorkerTestEnvironment();
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("bootstraps, schedules cleanup, and creates the worker", async () => {
+    mockAuthWorkerTestEnvironment.cleanupAllExpiredUnverifiedUsers.mockResolvedValue(
+      3,
+    );
+
+    await startUnverifiedAccountCleanupWorker();
+
+    expect(
+      mockAuthWorkerTestEnvironment.cleanupAllExpiredUnverifiedUsers,
+    ).toHaveBeenCalledTimes(1);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "[unverifiedAccountCleanup:init]",
+      { initialCleanedCount: 3 },
+    );
+    expect(
+      mockAuthWorkerTestEnvironment.unverifiedAccountCleanupQueueAdd,
+    ).toHaveBeenCalledWith(
+      CLEANUP_JOB_NAME,
+      {},
+      expect.objectContaining({
+        repeat: { every: CLEANUP_REPEAT_EVERY_MS },
+        removeOnComplete: true,
+        removeOnFail: false,
+        jobId: "cleanup-expired-unverified-accounts",
+      }),
+    );
+
+    expect(mockAuthWorkerTestEnvironment.workerInstances).toHaveLength(1);
+    const worker = mockAuthWorkerTestEnvironment.workerInstances[0];
+
+    expect(worker.name).toBe("unverifiedAccountCleanupQueue");
+    expect(worker.options).toMatchObject({
+      connection: mockAuthWorkerTestEnvironment.redisMessagingClientConnection,
+      concurrency: 1,
+      limiter: {
+        max: 1,
+        duration: 1000,
+      },
+    });
+    expect(worker.events.has("completed")).toBe(true);
+    expect(worker.events.has("failed")).toBe(true);
+    expect(worker.events.has("error")).toBe(true);
+  });
+
+  it("ignores unrelated jobs", async () => {
+    mockAuthWorkerTestEnvironment.cleanupAllExpiredUnverifiedUsers.mockResolvedValue(
+      1,
+    );
+
+    await startUnverifiedAccountCleanupWorker();
+
+    const worker = mockAuthWorkerTestEnvironment.workerInstances[0];
+    const result = await worker.processor({
+      name: "SOME_OTHER_JOB",
+      id: "job-1",
+    });
+
+    expect(result).toBeUndefined();
+    expect(
+      mockAuthWorkerTestEnvironment.cleanupAllExpiredUnverifiedUsers,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs cleanup jobs and returns the cleaned count", async () => {
+    mockAuthWorkerTestEnvironment.cleanupAllExpiredUnverifiedUsers.mockResolvedValue(
+      2,
+    );
+
+    await startUnverifiedAccountCleanupWorker();
+
+    const worker = mockAuthWorkerTestEnvironment.workerInstances[0];
+    const result = await worker.processor({
+      name: CLEANUP_JOB_NAME,
+      id: "job-1",
+    });
+
+    expect(result).toBe(2);
+    expect(
+      mockAuthWorkerTestEnvironment.cleanupAllExpiredUnverifiedUsers,
+    ).toHaveBeenCalledTimes(2);
+    expect(consoleLogSpy).toHaveBeenCalledWith("[unverifiedAccountCleanup]", {
+      cleanedCount: 2,
+    });
+  });
+});

--- a/tests/integration/workers/email/email.int.test.ts
+++ b/tests/integration/workers/email/email.int.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockEmailWorkerModules,
+  mockEmailWorkerTestEnvironment,
+  resetEmailWorkerTestEnvironment,
+} from "../../../helpers/mockEmailWorkerTestEnvironment.js";
+
+vi.mock("bullmq", () => mockEmailWorkerModules.bullmq);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockEmailWorkerModules.redisConfig,
+);
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockEmailWorkerModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/nodemailer.config.js",
+  () => mockEmailWorkerModules.nodemailerConfig,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockEmailWorkerModules.unverifiedAccountCleanupService,
+);
+
+const { startEmailWorker } = await import("../../../../src/workers/email.worker.js");
+
+describe("email worker", () => {
+  const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const originalEmail = process.env.QANOPY_EMAIL;
+
+  beforeEach(() => {
+    resetEmailWorkerTestEnvironment();
+    process.env.QANOPY_EMAIL = "noreply@qanopy.test";
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+  });
+
+  afterEach(() => {
+    process.env.QANOPY_EMAIL = originalEmail;
+    vi.clearAllMocks();
+  });
+
+  it("creates the worker with the expected config", async () => {
+    await startEmailWorker();
+
+    expect(mockEmailWorkerTestEnvironment.workerInstances).toHaveLength(1);
+    const worker = mockEmailWorkerTestEnvironment.workerInstances[0];
+
+    expect(worker.name).toBe("emailQueue");
+    expect(worker.options).toMatchObject({
+      connection: mockEmailWorkerTestEnvironment.redisMessagingClientConnection,
+      concurrency: 20,
+      limiter: {
+        max: 20,
+        duration: 1000,
+      },
+    });
+    expect(worker.events.has("completed")).toBe(true);
+    expect(worker.events.has("failed")).toBe(true);
+    expect(worker.events.has("error")).toBe(true);
+  });
+
+  it("sends email when no userId is present", async () => {
+    await startEmailWorker();
+
+    const worker = mockEmailWorkerTestEnvironment.workerInstances[0];
+    await worker.processor({
+      name: "SEND",
+      id: "job-1",
+      data: {
+        email: "alice@example.com",
+        subject: "Hello",
+        htmlContent: "<p>Hello</p>",
+      },
+    });
+
+    expect(mockEmailWorkerTestEnvironment.sendMail).toHaveBeenCalledWith({
+      from: "'Qanopy' <noreply@qanopy.test>",
+      to: "alice@example.com",
+      subject: "Hello",
+      html: "<p>Hello</p>",
+    });
+  });
+
+  it("skips missing users and deleted or non-local users", async () => {
+    await startEmailWorker();
+
+    const worker = mockEmailWorkerTestEnvironment.workerInstances[0];
+
+    mockEmailWorkerTestEnvironment.prismaUserFindUnique.mockResolvedValueOnce(null);
+    await worker.processor({
+      name: "VERIFY",
+      id: "job-1",
+      data: {
+        email: "alice@example.com",
+        subject: "Verify",
+        htmlContent: "<p>Verify</p>",
+        userId: "user_1",
+        purpose: "VERIFY_EMAIL",
+      },
+    });
+
+    mockEmailWorkerTestEnvironment.prismaUserFindUnique.mockResolvedValueOnce({
+      id: "user_1",
+      email: "alice@example.com",
+      createdAt: new Date(),
+      authProvider: "LOCAL",
+      isVerified: false,
+      isDeleted: true,
+    });
+    await worker.processor({
+      name: "VERIFY",
+      id: "job-2",
+      data: {
+        email: "alice@example.com",
+        subject: "Verify",
+        htmlContent: "<p>Verify</p>",
+        userId: "user_1",
+        purpose: "VERIFY_EMAIL",
+      },
+    });
+
+    mockEmailWorkerTestEnvironment.prismaUserFindUnique.mockResolvedValueOnce({
+      id: "user_1",
+      email: "alice@example.com",
+      createdAt: new Date(),
+      authProvider: "GOOGLE",
+      isVerified: false,
+      isDeleted: false,
+    });
+    await worker.processor({
+      name: "VERIFY",
+      id: "job-3",
+      data: {
+        email: "alice@example.com",
+        subject: "Verify",
+        htmlContent: "<p>Verify</p>",
+        userId: "user_1",
+        purpose: "VERIFY_EMAIL",
+      },
+    });
+
+    expect(mockEmailWorkerTestEnvironment.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("skips verify email jobs for verified or expired users", async () => {
+    await startEmailWorker();
+
+    const worker = mockEmailWorkerTestEnvironment.workerInstances[0];
+
+    mockEmailWorkerTestEnvironment.prismaUserFindUnique.mockResolvedValueOnce({
+      id: "user_1",
+      email: "alice@example.com",
+      createdAt: new Date(),
+      authProvider: "LOCAL",
+      isVerified: true,
+      isDeleted: false,
+    });
+    await worker.processor({
+      name: "VERIFY",
+      id: "job-1",
+      data: {
+        email: "alice@example.com",
+        subject: "Verify",
+        htmlContent: "<p>Verify</p>",
+        userId: "user_1",
+        purpose: "VERIFY_EMAIL",
+      },
+    });
+
+    mockEmailWorkerTestEnvironment.prismaUserFindUnique.mockResolvedValueOnce({
+      id: "user_2",
+      email: "bob@example.com",
+      createdAt: new Date(),
+      authProvider: "LOCAL",
+      isVerified: false,
+      isDeleted: false,
+    });
+    mockEmailWorkerTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValueOnce(
+      true,
+    );
+    await worker.processor({
+      name: "VERIFY",
+      id: "job-2",
+      data: {
+        email: "bob@example.com",
+        subject: "Verify",
+        htmlContent: "<p>Verify</p>",
+        userId: "user_2",
+        purpose: "VERIFY_EMAIL",
+      },
+    });
+
+    expect(mockEmailWorkerTestEnvironment.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("sends reset password emails for valid users", async () => {
+    await startEmailWorker();
+
+    const worker = mockEmailWorkerTestEnvironment.workerInstances[0];
+    mockEmailWorkerTestEnvironment.prismaUserFindUnique.mockResolvedValueOnce({
+      id: "user_1",
+      email: "alice@example.com",
+      createdAt: new Date(),
+      authProvider: "LOCAL",
+      isVerified: true,
+      isDeleted: false,
+    });
+
+    await worker.processor({
+      name: "RESET",
+      id: "job-1",
+      data: {
+        email: "alice@example.com",
+        subject: "Reset",
+        htmlContent: "<p>Reset</p>",
+        userId: "user_1",
+        purpose: "RESET_PASSWORD",
+      },
+    });
+
+    expect(mockEmailWorkerTestEnvironment.sendMail).toHaveBeenCalledWith({
+      from: "'Qanopy' <noreply@qanopy.test>",
+      to: "alice@example.com",
+      subject: "Reset",
+      html: "<p>Reset</p>",
+    });
+  });
+});

--- a/tests/unit/services/auth/auth.shared.unit.test.ts
+++ b/tests/unit/services/auth/auth.shared.unit.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const {
+  getDeviceIp,
+  cacheUser,
+  cacheAuthUser,
+  removeResetPasswordAttempts,
+  handleExpiredUnverifiedUser,
+} = await import("../../../../src/services/auth/auth.shared.js");
+
+describe("auth.shared", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockReset();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReset();
+  });
+
+  it("normalizes device IPs", () => {
+    expect(
+      getDeviceIp({ browser: "Chrome", os: "Linux", ip: "127.0.0.1" }),
+    ).toBe("127.0.0.1");
+    expect(
+      getDeviceIp({ browser: "Chrome", os: "Linux", ip: ["1.1.1.1"] }),
+    ).toBe("1.1.1.1");
+    expect(getDeviceIp({ browser: "Chrome", os: "Linux" })).toBe("Unknown IP");
+  });
+
+  it("caches user records", async () => {
+    await cacheUser({
+      id: "user_1",
+      email: "alice@example.com",
+      password: "secret",
+      tokenVersion: 1,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    } as any);
+
+    expect(authUnitTestEnvironment.redisStore.get("user:user_1")).toContain(
+      '"email":"alice@example.com"',
+    );
+  });
+
+  it("caches auth user records", async () => {
+    await cacheAuthUser({
+      id: "user_1",
+      tokenVersion: 1,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "ADMIN",
+      isDeleted: false,
+    } as any);
+
+    expect(
+      authUnitTestEnvironment.redisStore.get("auth:user:user_1"),
+    ).toContain('"role":"ADMIN"');
+  });
+
+  it("removes reset password attempts", async () => {
+    await removeResetPasswordAttempts("user_1");
+
+    expect(authUnitTestEnvironment.redisDel).toHaveBeenCalledWith(
+      "auth:reset-password:attempts:user_1",
+    );
+  });
+
+  it("only cleans up expired unverified users", async () => {
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(true);
+
+    const cleaned = await handleExpiredUnverifiedUser({
+      id: "user_1",
+      createdAt: new Date("2020-01-01"),
+      authProvider: "LOCAL",
+      isVerified: false,
+    } as any);
+
+    expect(cleaned).toBe(true);
+    expect(
+      authUnitTestEnvironment.cleanupExpiredUnverifiedUserById,
+    ).toHaveBeenCalledWith("user_1");
+  });
+
+  it("does not clean up verified users", async () => {
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+
+    await expect(
+      handleExpiredUnverifiedUser({
+        id: "user_1",
+        createdAt: new Date("2020-01-01"),
+        authProvider: "LOCAL",
+        isVerified: true,
+      } as any),
+    ).resolves.toBe(false);
+  });
+});

--- a/tests/unit/services/auth/changePassword.unit.test.ts
+++ b/tests/unit/services/auth/changePassword.unit.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  seedBcryptCompareResult,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/utils/publishSocketDisconnect.util.js",
+  () => mockAuthUnitModules.publishSocketDisconnect,
+);
+
+const { default: changePassword } = await import(
+  "../../../../src/services/auth/changePassword.service.js"
+);
+
+describe("changePassword service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+  });
+
+  it("rejects missing users", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+
+    await expect(
+      changePassword({
+        userId: "user_1",
+        currentPassword: "Password1!",
+        newPassword: "Password2!",
+      }),
+    ).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 404,
+    });
+  });
+
+  it("rejects invalid current passwords", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      password: "hashed:Password1!:10",
+      authProvider: "LOCAL",
+    });
+    seedBcryptCompareResult("Password1!", "hashed:Password1!:10", false);
+
+    await expect(
+      changePassword({
+        userId: "user_1",
+        currentPassword: "Password1!",
+        newPassword: "Password2!",
+      }),
+    ).rejects.toMatchObject({
+      message: "Invalid current password",
+      statusCode: 401,
+    });
+  });
+
+  it("rejects reusing the same password", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      password: "hashed:Password1!:10",
+      authProvider: "LOCAL",
+    });
+    seedBcryptCompareResult("Password1!", "hashed:Password1!:10", true);
+    seedBcryptCompareResult("Password2!", "hashed:Password1!:10", true);
+
+    await expect(
+      changePassword({
+        userId: "user_1",
+        currentPassword: "Password1!",
+        newPassword: "Password2!",
+      }),
+    ).rejects.toMatchObject({
+      message: "New password must be different from the old password",
+      statusCode: 400,
+    });
+  });
+
+  it("updates the password and invalidates auth caches", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      password: "hashed:Password1!:10",
+      authProvider: "LOCAL",
+    });
+    seedBcryptCompareResult("Password1!", "hashed:Password1!:10", true);
+    seedBcryptCompareResult("Password2!", "hashed:Password1!:10", false);
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+      password: "hashed:Password2!:10",
+    });
+
+    const result = await changePassword({
+      userId: "user_1",
+      currentPassword: "Password1!",
+      newPassword: "Password2!",
+    });
+
+    expect(result.user.id).toBe("user_1");
+    expect(
+      authUnitTestEnvironment.publishSocketDisconnect,
+    ).toHaveBeenCalledWith("user_1");
+    expect(authUnitTestEnvironment.redisDel).toHaveBeenCalledWith(
+      "auth:reset-password:attempts:user_1",
+    );
+    expect(authUnitTestEnvironment.redisSet).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/auth/deleteAccount.unit.test.ts
+++ b/tests/unit/services/auth/deleteAccount.unit.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock(
+  "../../../../src/models/notification.model.js",
+  () => mockAuthUnitModules.notificationModel,
+);
+vi.mock(
+  "../../../../src/models/userInterest.model.js",
+  () => mockAuthUnitModules.userInterestModel,
+);
+vi.mock(
+  "../../../../src/services/media/deleteSingleImage.service.js",
+  () => mockAuthUnitModules.deleteSingleImageService,
+);
+vi.mock(
+  "../../../../src/utils/buildDeletedUserData.util.js",
+  () => mockAuthUnitModules.buildDeletedUserData,
+);
+vi.mock(
+  "../../../../src/utils/clearCache.util.js",
+  () => mockAuthUnitModules.clearCacheUtil,
+);
+
+const {
+  default: deleteAccount,
+  purgeAccountData,
+  softDeleteAccount,
+} = await import("../../../../src/services/auth/deleteAccount.service.js");
+
+describe("deleteAccount service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+  });
+
+  it("purges account data", async () => {
+    await purgeAccountData({
+      userId: "user_1",
+      profilePictureKey: "profile-key",
+    });
+
+    expect(
+      authUnitTestEnvironment.deleteSingleImageService,
+    ).toHaveBeenCalledWith({
+      objectKey: "profile-key",
+    });
+    expect(authUnitTestEnvironment.clearNotificationCache).toHaveBeenCalledWith(
+      "user_1",
+    );
+  });
+
+  it("soft deletes accounts", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      status: "ACTIVE",
+      isDeleted: false,
+      deletedAt: null,
+      accountDeletionCompletedAt: null,
+    });
+    authUnitTestEnvironment.buildDeletedUserData.mockResolvedValue({
+      status: "DELETED",
+      isDeleted: true,
+    });
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+      accountDeletionCompletedAt: new Date(),
+    });
+
+    const result = await softDeleteAccount("user_1");
+
+    expect(result?.id).toBe("user_1");
+    expect(authUnitTestEnvironment.prismaUserUpdate).toHaveBeenCalled();
+  });
+
+  it("runs the full delete account flow", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      status: "ACTIVE",
+      isDeleted: false,
+      deletedAt: null,
+      accountDeletionCompletedAt: null,
+    });
+    authUnitTestEnvironment.buildDeletedUserData.mockResolvedValue({
+      status: "DELETED",
+      isDeleted: true,
+    });
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+      accountDeletionCompletedAt: new Date(),
+    });
+
+    await deleteAccount({
+      userId: "user_1",
+      profilePictureKey: "profile-key",
+    });
+
+    expect(authUnitTestEnvironment.clearNotificationCache).toHaveBeenCalledWith(
+      "user_1",
+    );
+  });
+});

--- a/tests/unit/services/auth/isAuth.unit.test.ts
+++ b/tests/unit/services/auth/isAuth.unit.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  seedRedisValue,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+
+const { default: isAuth } = await import(
+  "../../../../src/services/auth/isAuth.service.js"
+);
+
+describe("isAuth service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+  });
+
+  it("rejects missing users", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+
+    await expect(isAuth({ userId: "user_1" })).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 404,
+    });
+  });
+
+  it("loads from prisma on cache miss and re-caches the user", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+
+    const result = await isAuth({ userId: "user_1" });
+
+    expect(result.user.id).toBe("user_1");
+    expect(authUnitTestEnvironment.redisStore.get("user:user_1")).toBeTruthy();
+  });
+
+  it("uses cached users on a cache hit", async () => {
+    seedRedisValue("user:user_1", {
+      id: "user_1",
+      email: "alice@example.com",
+      tokenVersion: 0,
+      status: "ACTIVE",
+      isVerified: true,
+      role: "USER",
+      isDeleted: false,
+    });
+
+    const result = await isAuth({ userId: "user_1" });
+
+    expect(result.user.id).toBe("user_1");
+    expect(authUnitTestEnvironment.prismaUserFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/auth/login.unit.test.ts
+++ b/tests/unit/services/auth/login.unit.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  seedBcryptCompareResult,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: login } = await import(
+  "../../../../src/services/auth/login.service.js"
+);
+
+describe("login service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects missing users", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue(null);
+
+    await expect(
+      login({ email: "alice@example.com", password: "Password1!" }),
+    ).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 400,
+    });
+  });
+
+  it("rejects users without passwords", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      password: null,
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+    });
+
+    await expect(
+      login({ email: "alice@example.com", password: "Password1!" }),
+    ).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 400,
+    });
+  });
+
+  it("rejects expired unverified users", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      password: "hashed",
+      authProvider: "LOCAL",
+      isVerified: false,
+      createdAt: new Date("2020-01-01"),
+    });
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(true);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      true,
+    );
+
+    await expect(
+      login({ email: "alice@example.com", password: "Password1!" }),
+    ).rejects.toMatchObject({
+      message: "Email verification expired, please sign up again",
+      statusCode: 410,
+    });
+  });
+
+  it("rejects wrong passwords", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      password: "hashed:real-password",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+    });
+    seedBcryptCompareResult("Password1!", "hashed:real-password", false);
+
+    await expect(
+      login({ email: "alice@example.com", password: "Password1!" }),
+    ).rejects.toMatchObject({
+      message: "Invalid password",
+      statusCode: 401,
+    });
+  });
+
+  it("caches the user after a successful login", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      password: "hashed:real-password",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      tokenVersion: 2,
+      status: "ACTIVE",
+      role: "USER",
+      isDeleted: false,
+    });
+    seedBcryptCompareResult("Password1!", "hashed:real-password", true);
+
+    const result = await login({
+      email: "alice@example.com",
+      password: "Password1!",
+    });
+
+    expect(result.user.email).toBe("alice@example.com");
+    expect(authUnitTestEnvironment.redisStore.get("user:user_1")).toBeTruthy();
+  });
+});

--- a/tests/unit/services/auth/register.unit.test.ts
+++ b/tests/unit/services/auth/register.unit.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/queues/email.queue.js",
+  () => mockAuthUnitModules.emailQueue,
+);
+vi.mock(
+  "../../../../src/utils/makeJobId.util.js",
+  () => mockAuthUnitModules.makeJobId,
+);
+vi.mock(
+  "../../../../src/utils/renderTemplate.util.js",
+  () => mockAuthUnitModules.renderTemplate,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: register } = await import(
+  "../../../../src/services/auth/register.service.js"
+);
+
+describe("register service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+    authUnitTestEnvironment.verificationHtml.mockReturnValue(
+      "<verification-email>",
+    );
+    authUnitTestEnvironment.makeUniqueJobId.mockReturnValue("job-id");
+    vi.spyOn(Math, "random").mockReturnValue(0.123456);
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects duplicate emails unless the user is expired and unverified", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      createdAt: new Date("2020-01-01"),
+      authProvider: "LOCAL",
+      isVerified: true,
+    });
+
+    await expect(
+      register({
+        username: "alice",
+        email: "alice@example.com",
+        password: "Password1!",
+        deviceInfo: { browser: "Chrome", os: "Linux" },
+      }),
+    ).rejects.toMatchObject({
+      message: "Email is already in use",
+      statusCode: 400,
+    });
+  });
+
+  it("registers a user, caches it, and queues a verification email", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue(null);
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+    authUnitTestEnvironment.prismaUserCreate.mockResolvedValue({
+      id: "user_1",
+      username: "alice",
+      email: "alice@example.com",
+      password: "hashed:Password1!:10",
+      otp: "hashed:211110:6",
+      otpExpireAt: new Date(1_700_000_120_000),
+      otpResendAvailableAt: new Date(1_700_000_030_000),
+      authProvider: "LOCAL",
+      isVerified: false,
+      status: "PENDING",
+      isDeleted: false,
+    });
+
+    const result = await register({
+      username: "alice",
+      email: "alice@example.com",
+      password: "Password1!",
+      deviceInfo: {
+        browser: "Chrome",
+        os: "Linux",
+        ip: "127.0.0.1",
+      },
+    });
+
+    expect(authUnitTestEnvironment.bcryptHash).toHaveBeenNthCalledWith(
+      1,
+      "Password1!",
+      10,
+    );
+    expect(authUnitTestEnvironment.bcryptHash).toHaveBeenNthCalledWith(
+      2,
+      "211110",
+      6,
+    );
+    expect(authUnitTestEnvironment.prismaTransaction).toHaveBeenCalled();
+    expect(authUnitTestEnvironment.prismaUserCreate).toHaveBeenCalledWith({
+      data: {
+        username: "alice",
+        email: "alice@example.com",
+        password: "hashed:Password1!:10",
+        otp: "hashed:211110:6",
+        otpExpireAt: new Date(1_700_000_120_000),
+        otpResendAvailableAt: new Date(1_700_000_030_000),
+        moderationStats: { create: {} },
+        notificationSettings: { create: {} },
+      },
+    });
+    expect(authUnitTestEnvironment.redisStore.get("user:user_1")).toBeTruthy();
+    expect(authUnitTestEnvironment.verificationHtml).toHaveBeenCalledWith(
+      "alice",
+      "211110",
+      "Chrome on Linux",
+      "127.0.0.1",
+    );
+    expect(authUnitTestEnvironment.emailQueueAdd).toHaveBeenCalledWith(
+      "SEND_VERIFICATION_EMAIL",
+      expect.objectContaining({
+        email: "alice@example.com",
+        userId: "user_1",
+        purpose: "VERIFY_EMAIL",
+        subject: "Verify Email",
+        htmlContent: "<verification-email>",
+      }),
+      expect.objectContaining({
+        removeOnComplete: true,
+        removeOnFail: false,
+        jobId: "job-id",
+      }),
+    );
+    expect(result.user.id).toBe("user_1");
+    expect(result.otpExpireAt).toEqual(new Date(1_700_000_120_000));
+  });
+
+  it("cleans up expired unverified users instead of blocking registration", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_old",
+      createdAt: new Date("2020-01-01"),
+      authProvider: "LOCAL",
+      isVerified: false,
+    });
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(true);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      true,
+    );
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+    authUnitTestEnvironment.prismaUserCreate.mockResolvedValue({
+      id: "user_2",
+      username: "alice",
+      email: "alice@example.com",
+      password: "hashed:Password1!:10",
+      otp: "hashed:223456:6",
+      otpExpireAt: new Date(1_700_000_120_000),
+      otpResendAvailableAt: new Date(1_700_000_030_000),
+      authProvider: "LOCAL",
+      isVerified: false,
+      status: "PENDING",
+      isDeleted: false,
+    });
+
+    await register({
+      username: "alice",
+      email: "alice@example.com",
+      password: "Password1!",
+      deviceInfo: { browser: "Chrome", os: "Linux" },
+    });
+
+    expect(
+      authUnitTestEnvironment.cleanupExpiredUnverifiedUserById,
+    ).toHaveBeenCalledWith("user_old");
+  });
+});

--- a/tests/unit/services/auth/registerOrLogin.unit.test.ts
+++ b/tests/unit/services/auth/registerOrLogin.unit.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock(
+  "../../../../src/utils/generateOAuthUsername.util.js",
+  () => mockAuthUnitModules.generateOAuthUsername,
+);
+vi.mock(
+  "../../../../src/utils/verifyGoogleToken.util.js",
+  () => mockAuthUnitModules.verifyGoogleToken,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: registerOrLogin } = await import(
+  "../../../../src/services/auth/registerOrLogin.service.js"
+);
+
+describe("registerOrLogin service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+    authUnitTestEnvironment.generateOAuthUsername.mockResolvedValue(
+      "oauth-user",
+    );
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects google tokens with unverified emails", async () => {
+    authUnitTestEnvironment.verifyGoogleToken.mockResolvedValue({
+      email: "alice@example.com",
+      name: "Alice",
+      picture: "pic",
+      email_verified: false,
+      googleId: "g-1",
+    });
+
+    await expect(
+      registerOrLogin({ provider: "google", idToken: "token" }),
+    ).rejects.toMatchObject({
+      message: "Email not verified, couldn't register",
+      statusCode: 400,
+    });
+  });
+
+  it("registers new google users", async () => {
+    authUnitTestEnvironment.verifyGoogleToken.mockResolvedValue({
+      email: "alice@example.com",
+      name: "Alice",
+      picture: "pic",
+      email_verified: true,
+      googleId: "g-1",
+    });
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue(null);
+    authUnitTestEnvironment.prismaUserCreate.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      username: "oauth-user",
+      profilePictureUrl: "pic",
+      authProvider: "GOOGLE",
+      isVerified: true,
+      status: "ACTIVE",
+      isDeleted: false,
+    });
+
+    const result = await registerOrLogin({
+      provider: "google",
+      idToken: "token",
+    });
+
+    expect(result.action).toBe("registered");
+    expect(authUnitTestEnvironment.prismaUserCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        username: "oauth-user",
+        email: "alice@example.com",
+        profilePictureUrl: "pic",
+        isVerified: true,
+        authProvider: "GOOGLE",
+      }),
+    });
+  });
+
+  it("logs in existing google users", async () => {
+    authUnitTestEnvironment.verifyGoogleToken.mockResolvedValue({
+      email: "alice@example.com",
+      name: "Alice",
+      picture: "pic",
+      email_verified: true,
+      googleId: "g-1",
+    });
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      username: "oauth-user",
+      authProvider: "GOOGLE",
+      isVerified: true,
+      status: "ACTIVE",
+      isDeleted: false,
+    });
+
+    const result = await registerOrLogin({
+      provider: "google",
+      idToken: "token",
+    });
+
+    expect(result.action).toBe("loggedIn");
+    expect(authUnitTestEnvironment.redisStore.get("user:user_1")).toBeTruthy();
+  });
+
+  it("rejects github tokens that do not contain required fields", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      json: async () => ({ email: null, name: null }),
+    });
+
+    await expect(
+      registerOrLogin({ provider: "github", accessToken: "token" }),
+    ).rejects.toMatchObject({
+      message: "Invalid Github access token",
+      statusCode: 400,
+    });
+  });
+
+  it("registers new github users", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      json: async () => ({
+        email: "alice@example.com",
+        name: "Alice",
+        avatar_url: "avatar",
+      }),
+    });
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue(null);
+    authUnitTestEnvironment.prismaUserCreate.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      username: "oauth-user",
+      profilePictureUrl: "avatar",
+      authProvider: "GITHUB",
+      isVerified: true,
+      status: "ACTIVE",
+      isDeleted: false,
+    });
+
+    const result = await registerOrLogin({
+      provider: "github",
+      accessToken: "token",
+    });
+
+    expect(result.action).toBe("registered");
+    expect(authUnitTestEnvironment.prismaUserCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        username: "oauth-user",
+        email: "alice@example.com",
+        profilePictureUrl: "avatar",
+        isVerified: true,
+        authProvider: "GITHUB",
+      }),
+    });
+  });
+});

--- a/tests/unit/services/auth/resendResetPasswordEmail.unit.test.ts
+++ b/tests/unit/services/auth/resendResetPasswordEmail.unit.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/queues/email.queue.js",
+  () => mockAuthUnitModules.emailQueue,
+);
+vi.mock(
+  "../../../../src/utils/makeJobId.util.js",
+  () => mockAuthUnitModules.makeJobId,
+);
+vi.mock(
+  "../../../../src/utils/renderTemplate.util.js",
+  () => mockAuthUnitModules.renderTemplate,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: resendResetPasswordEmail } = await import(
+  "../../../../src/services/auth/resendResetPasswordEmail.service.js"
+);
+
+describe("resendResetPasswordEmail service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+    authUnitTestEnvironment.resetPasswordHtml.mockReturnValue(
+      "<reset-password-email>",
+    );
+    authUnitTestEnvironment.makeUniqueJobId.mockReturnValue("job-id");
+  });
+
+  it("rejects missing users", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue(null);
+
+    await expect(
+      resendResetPasswordEmail({
+        email: "alice@example.com",
+        deviceInfo: { browser: "Chrome", os: "Linux" },
+      }),
+    ).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 404,
+    });
+  });
+
+  it("rejects resend cooldown", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: "hashed-otp",
+      resetPasswordOtpExpireAt: new Date(Date.now() + 10_000),
+      resetPasswordOtpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+
+    await expect(
+      resendResetPasswordEmail({
+        email: "alice@example.com",
+        deviceInfo: { browser: "Chrome", os: "Linux" },
+      }),
+    ).rejects.toMatchObject({
+      message: "OTP resend will soon be available, please wait",
+      statusCode: 400,
+    });
+  });
+
+  it("queues a resend reset password email", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: "hashed-otp",
+      resetPasswordOtpExpireAt: new Date(Date.now() - 1_000),
+      resetPasswordOtpResendAvailableAt: new Date(Date.now() - 1_000),
+    });
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: "hashed-new-otp",
+      resetPasswordOtpExpireAt: new Date(),
+      resetPasswordOtpResendAvailableAt: new Date(),
+    });
+
+    const result = await resendResetPasswordEmail({
+      email: "alice@example.com",
+      deviceInfo: { browser: "Chrome", os: "Linux", ip: "127.0.0.1" },
+    });
+
+    expect(result).toEqual({ sent: true });
+    expect(authUnitTestEnvironment.emailQueueAdd).toHaveBeenCalledWith(
+      "RESEND_RESET_PASSWORD_EMAIL",
+      expect.objectContaining({
+        email: "alice@example.com",
+        userId: "user_1",
+        purpose: "RESET_PASSWORD",
+        subject: "Reset Password Request",
+        htmlContent: "<reset-password-email>",
+      }),
+      expect.objectContaining({
+        jobId: "job-id",
+      }),
+    );
+  });
+});

--- a/tests/unit/services/auth/resendVerificationEmail.unit.test.ts
+++ b/tests/unit/services/auth/resendVerificationEmail.unit.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/queues/email.queue.js",
+  () => mockAuthUnitModules.emailQueue,
+);
+vi.mock(
+  "../../../../src/utils/makeJobId.util.js",
+  () => mockAuthUnitModules.makeJobId,
+);
+vi.mock(
+  "../../../../src/utils/renderTemplate.util.js",
+  () => mockAuthUnitModules.renderTemplate,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: resendVerificationEmail } = await import(
+  "../../../../src/services/auth/resendVerificationEmail.service.js"
+);
+
+describe("resendVerificationEmail service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+    authUnitTestEnvironment.makeUniqueJobId.mockReturnValue("job-id");
+    authUnitTestEnvironment.verificationHtml.mockReturnValue(
+      "<verification-email>",
+    );
+  });
+
+  it("rejects missing users", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+
+    await expect(
+      resendVerificationEmail({
+        userId: "user_1",
+        deviceInfo: { browser: "Chrome", os: "Linux" },
+      }),
+    ).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 404,
+    });
+  });
+
+  it("rejects resend cooldown", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: false,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      otp: "hashed-otp",
+      otpExpireAt: new Date(Date.now() + 10_000),
+      otpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+
+    await expect(
+      resendVerificationEmail({
+        userId: "user_1",
+        deviceInfo: { browser: "Chrome", os: "Linux" },
+      }),
+    ).rejects.toMatchObject({
+      message: "OTP resend will soon be available, please wait",
+      statusCode: 400,
+    });
+  });
+
+  it("resends and queues a new verification email", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: false,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      otp: "hashed-otp",
+      otpExpireAt: new Date(Date.now() - 1_000),
+      otpResendAvailableAt: new Date(Date.now() - 1_000),
+    });
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: false,
+      email: "alice@example.com",
+      username: "alice",
+      otp: "hashed-new-otp",
+      otpExpireAt: new Date(),
+      otpResendAvailableAt: new Date(),
+    });
+
+    const result = await resendVerificationEmail({
+      userId: "user_1",
+      deviceInfo: { browser: "Chrome", os: "Linux", ip: "127.0.0.1" },
+    });
+
+    expect(result.user.id).toBe("user_1");
+    expect(authUnitTestEnvironment.emailQueueAdd).toHaveBeenCalledWith(
+      "RESEND_VERIFICATION_EMAIL",
+      expect.objectContaining({
+        email: "alice@example.com",
+        userId: "user_1",
+        purpose: "VERIFY_EMAIL",
+        subject: "Verify Email",
+        htmlContent: "<verification-email>",
+      }),
+      expect.objectContaining({
+        jobId: "job-id",
+      }),
+    );
+  });
+});

--- a/tests/unit/services/auth/resetPassword.unit.test.ts
+++ b/tests/unit/services/auth/resetPassword.unit.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  seedBcryptCompareResult,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/utils/publishSocketDisconnect.util.js",
+  () => mockAuthUnitModules.publishSocketDisconnect,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: resetPassword } = await import(
+  "../../../../src/services/auth/resetPassword.service.js"
+);
+
+describe("resetPassword service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+  });
+
+  it("rejects missing users", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue(null);
+
+    await expect(
+      resetPassword({ email: "alice@example.com", newPassword: "Password2!" }),
+    ).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 404,
+    });
+  });
+
+  it("rejects when otp is not verified", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      password: "hashed:Password1!:10",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtpVerified: false,
+    });
+
+    await expect(
+      resetPassword({ email: "alice@example.com", newPassword: "Password2!" }),
+    ).rejects.toMatchObject({
+      message: "OTP not verified",
+      statusCode: 400,
+    });
+  });
+
+  it("rejects reusing the same password", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      password: "hashed:Password1!:10",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtpVerified: true,
+    });
+    seedBcryptCompareResult("Password2!", "hashed:Password1!:10", true);
+
+    await expect(
+      resetPassword({ email: "alice@example.com", newPassword: "Password2!" }),
+    ).rejects.toMatchObject({
+      message: "New password must be different from the old password",
+      statusCode: 400,
+    });
+  });
+
+  it("updates the password, clears cache, and publishes socket disconnect", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      password: "hashed:Password1!:10",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtpVerified: true,
+    });
+    seedBcryptCompareResult("Password2!", "hashed:Password1!:10", false);
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      password: "hashed:Password2!:10",
+    });
+
+    const result = await resetPassword({
+      email: "alice@example.com",
+      newPassword: "Password2!",
+    });
+
+    expect(result.user.id).toBe("user_1");
+    expect(
+      authUnitTestEnvironment.publishSocketDisconnect,
+    ).toHaveBeenCalledWith("user_1");
+    expect(authUnitTestEnvironment.redisDel).toHaveBeenCalledWith(
+      "auth:user:user_1",
+    );
+    expect(authUnitTestEnvironment.redisDel).toHaveBeenCalledWith(
+      "user:user_1",
+    );
+  });
+});

--- a/tests/unit/services/auth/sendResetPasswordEmail.unit.test.ts
+++ b/tests/unit/services/auth/sendResetPasswordEmail.unit.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/queues/email.queue.js",
+  () => mockAuthUnitModules.emailQueue,
+);
+vi.mock(
+  "../../../../src/utils/makeJobId.util.js",
+  () => mockAuthUnitModules.makeJobId,
+);
+vi.mock(
+  "../../../../src/utils/renderTemplate.util.js",
+  () => mockAuthUnitModules.renderTemplate,
+);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: sendResetPasswordEmail } = await import(
+  "../../../../src/services/auth/sendResetPasswordEmail.service.js"
+);
+
+describe("sendResetPasswordEmail service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+    authUnitTestEnvironment.resetPasswordHtml.mockReturnValue(
+      "<reset-password-email>",
+    );
+    authUnitTestEnvironment.makeUniqueJobId.mockReturnValue("job-id");
+  });
+
+  it("returns a neutral success response for missing or non-local users", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue(null);
+
+    await expect(
+      sendResetPasswordEmail({
+        email: "alice@example.com",
+        deviceInfo: { browser: "Chrome", os: "Linux" },
+      }),
+    ).resolves.toEqual({ sent: true });
+  });
+
+  it("rejects when an active reset otp already exists", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: "hashed-otp",
+      resetPasswordOtpExpireAt: new Date(Date.now() + 10_000),
+      resetPasswordOtpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+
+    await expect(
+      sendResetPasswordEmail({
+        email: "alice@example.com",
+        deviceInfo: { browser: "Chrome", os: "Linux" },
+      }),
+    ).rejects.toMatchObject({
+      message: "Reset password OTP already sent",
+      statusCode: 400,
+    });
+  });
+
+  it("queues a reset password email for valid users", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: null,
+      resetPasswordOtpExpireAt: null,
+      resetPasswordOtpResendAvailableAt: null,
+    });
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: "hashed-otp",
+      resetPasswordOtpExpireAt: new Date(),
+      resetPasswordOtpResendAvailableAt: new Date(),
+    });
+
+    const result = await sendResetPasswordEmail({
+      email: "alice@example.com",
+      deviceInfo: { browser: "Chrome", os: "Linux", ip: "127.0.0.1" },
+    });
+
+    expect(result).toEqual({ sent: true });
+    expect(authUnitTestEnvironment.emailQueueAdd).toHaveBeenCalledWith(
+      "SEND_RESET_PASSWORD_EMAIL",
+      expect.objectContaining({
+        email: "alice@example.com",
+        userId: "user_1",
+        purpose: "RESET_PASSWORD",
+        subject: "Reset Password Request",
+        htmlContent: "<reset-password-email>",
+      }),
+      expect.objectContaining({
+        jobId: "job-id",
+      }),
+    );
+  });
+});

--- a/tests/unit/services/auth/unverifiedAccountCleanup.unit.test.ts
+++ b/tests/unit/services/auth/unverifiedAccountCleanup.unit.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock(
+  "../../../../src/utils/publishSocketDisconnect.util.js",
+  () => mockAuthUnitModules.publishSocketDisconnect,
+);
+vi.mock("../../../../src/services/auth/deleteAccount.service.js", () => ({
+  purgeAccountData: vi.fn(),
+}));
+
+const {
+  isExpiredUnverifiedLocalUser,
+  cleanupExpiredUnverifiedUserById,
+  cleanupAllExpiredUnverifiedUsers,
+} = await import(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js"
+);
+
+describe("unverifiedAccountCleanup service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+  });
+
+  it("detects expired unverified local users", () => {
+    expect(
+      isExpiredUnverifiedLocalUser({
+        createdAt: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000),
+        authProvider: "LOCAL",
+        isVerified: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not clean up users that are not expired", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      createdAt: new Date(),
+      authProvider: "LOCAL",
+      isVerified: false,
+      profilePictureKey: null,
+    });
+
+    await expect(cleanupExpiredUnverifiedUserById("user_1")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("cleans up expired users", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      createdAt: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000),
+      authProvider: "LOCAL",
+      isVerified: false,
+      profilePictureKey: "profile-key",
+    });
+    authUnitTestEnvironment.prismaUserDeleteMany.mockResolvedValue({
+      count: 1,
+    });
+
+    await expect(cleanupExpiredUnverifiedUserById("user_1")).resolves.toBe(
+      true,
+    );
+    expect(
+      authUnitTestEnvironment.publishSocketDisconnect,
+    ).toHaveBeenCalledWith("user_1");
+  });
+
+  it("counts expired users in the bulk cleanup", async () => {
+    authUnitTestEnvironment.prismaUserFindMany.mockResolvedValue([
+      { id: "user_1" },
+      { id: "user_2" },
+    ]);
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      email: "alice@example.com",
+      createdAt: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000),
+      authProvider: "LOCAL",
+      isVerified: false,
+      profilePictureKey: null,
+    });
+
+    await expect(
+      cleanupAllExpiredUnverifiedUsers(),
+    ).resolves.toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/unit/services/auth/verifyEmail.unit.test.ts
+++ b/tests/unit/services/auth/verifyEmail.unit.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  seedBcryptCompareResult,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: verifyEmail } = await import(
+  "../../../../src/services/auth/verifyEmail.service.js"
+);
+
+describe("verifyEmail service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+  });
+
+  it("rejects missing users", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue(null);
+
+    await expect(
+      verifyEmail({ userId: "user_1", otp: "123456" }),
+    ).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 404,
+    });
+  });
+
+  it("rejects non-local users", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      authProvider: "GOOGLE",
+      isVerified: false,
+      createdAt: new Date(),
+      otp: "hashed",
+      otpExpireAt: new Date(Date.now() + 10_000),
+      otpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+
+    await expect(
+      verifyEmail({ userId: "user_1", otp: "123456" }),
+    ).rejects.toMatchObject({
+      message: "Email verification not applicable",
+      statusCode: 400,
+    });
+  });
+
+  it("rejects invalid otp and increments attempts", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: false,
+      createdAt: new Date(),
+      otp: "hashed-otp",
+      otpExpireAt: new Date(Date.now() + 10_000),
+      otpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+    seedBcryptCompareResult("123456", "hashed-otp", false);
+
+    await expect(
+      verifyEmail({ userId: "user_1", otp: "123456" }),
+    ).rejects.toMatchObject({
+      message: "Invalid OTP",
+      statusCode: 400,
+    });
+
+    expect(authUnitTestEnvironment.redisMultiChain.incr).toHaveBeenCalledWith(
+      "auth:verify-email:attempts:user_1",
+    );
+  });
+
+  it("locks out after too many invalid attempts", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: false,
+      createdAt: new Date(),
+      otp: "hashed-otp",
+      otpExpireAt: new Date(Date.now() + 10_000),
+      otpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+    authUnitTestEnvironment.redisGet.mockResolvedValue("5");
+
+    await expect(
+      verifyEmail({ userId: "user_1", otp: "123456" }),
+    ).rejects.toMatchObject({
+      message: "Too many invalid attempts, OTP locked",
+      statusCode: 400,
+    });
+  });
+
+  it("verifies and clears otp state", async () => {
+    authUnitTestEnvironment.prismaUserFindUnique.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: false,
+      createdAt: new Date(),
+      otp: "hashed-otp",
+      otpExpireAt: new Date(Date.now() + 10_000),
+      otpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+    seedBcryptCompareResult("123456", "hashed-otp", true);
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      status: "ACTIVE",
+      isDeleted: false,
+    });
+
+    const result = await verifyEmail({ userId: "user_1", otp: "123456" });
+
+    expect(result.user.isVerified).toBe(true);
+    expect(authUnitTestEnvironment.redisDel).toHaveBeenCalledWith(
+      "auth:user:user_1",
+    );
+    expect(authUnitTestEnvironment.redisDel).toHaveBeenCalledWith(
+      "auth:verify-email:attempts:user_1",
+    );
+  });
+});

--- a/tests/unit/services/auth/verifyResetPasswordOtp.unit.test.ts
+++ b/tests/unit/services/auth/verifyResetPasswordOtp.unit.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockAuthUnitModules,
+  resetAuthUnitTestEnvironment,
+  seedBcryptCompareResult,
+  mockAuthUnitTestEnvironment as authUnitTestEnvironment,
+} from "../../../helpers/mockAuthUnitTestEnvironment.js";
+
+vi.mock(
+  "../../../../src/config/prisma.config.js",
+  () => mockAuthUnitModules.prismaConfig,
+);
+vi.mock(
+  "../../../../src/config/redis.config.js",
+  () => mockAuthUnitModules.redisConfig,
+);
+vi.mock("bcrypt", () => mockAuthUnitModules.bcrypt);
+vi.mock(
+  "../../../../src/services/auth/unverifiedAccountCleanup.service.js",
+  () => mockAuthUnitModules.unverifiedAccountCleanup,
+);
+
+const { default: verifyResetPasswordOtp } = await import(
+  "../../../../src/services/auth/verifyResetPasswordOtp.service.js"
+);
+
+describe("verifyResetPasswordOtp service", () => {
+  beforeEach(() => {
+    resetAuthUnitTestEnvironment();
+    authUnitTestEnvironment.isExpiredUnverifiedLocalUser.mockReturnValue(false);
+    authUnitTestEnvironment.cleanupExpiredUnverifiedUserById.mockResolvedValue(
+      false,
+    );
+  });
+
+  it("rejects missing users", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue(null);
+
+    await expect(
+      verifyResetPasswordOtp({ email: "alice@example.com", otp: "123456" }),
+    ).rejects.toMatchObject({
+      message: "Invalid credentials",
+      statusCode: 404,
+    });
+  });
+
+  it("rejects invalid otp and increments attempts", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: "hashed-otp",
+      resetPasswordOtpExpireAt: new Date(Date.now() + 10_000),
+      resetPasswordOtpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+    seedBcryptCompareResult("123456", "hashed-otp", false);
+
+    await expect(
+      verifyResetPasswordOtp({ email: "alice@example.com", otp: "123456" }),
+    ).rejects.toMatchObject({
+      message: "Invalid reset password OTP",
+      statusCode: 400,
+    });
+    expect(authUnitTestEnvironment.redisMultiChain.incr).toHaveBeenCalledWith(
+      "auth:reset-password:attempts:user_1",
+    );
+  });
+
+  it("rejects expired otp", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: "hashed-otp",
+      resetPasswordOtpExpireAt: new Date(Date.now() - 10_000),
+      resetPasswordOtpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+
+    await expect(
+      verifyResetPasswordOtp({ email: "alice@example.com", otp: "123456" }),
+    ).rejects.toMatchObject({
+      message: "Reset password OTP expired",
+      statusCode: 400,
+    });
+  });
+
+  it("marks otp as verified", async () => {
+    authUnitTestEnvironment.prismaUserFindFirst.mockResolvedValue({
+      id: "user_1",
+      authProvider: "LOCAL",
+      isVerified: true,
+      createdAt: new Date(),
+      email: "alice@example.com",
+      username: "alice",
+      resetPasswordOtp: "hashed-otp",
+      resetPasswordOtpExpireAt: new Date(Date.now() + 10_000),
+      resetPasswordOtpResendAvailableAt: new Date(Date.now() + 10_000),
+    });
+    seedBcryptCompareResult("123456", "hashed-otp", true);
+    authUnitTestEnvironment.prismaUserUpdate.mockResolvedValue({
+      id: "user_1",
+    });
+
+    const result = await verifyResetPasswordOtp({
+      email: "alice@example.com",
+      otp: "123456",
+    });
+
+    expect(result).toEqual({ verified: true });
+    expect(authUnitTestEnvironment.prismaUserUpdate).toHaveBeenCalledWith({
+      where: { id: "user_1" },
+      data: expect.objectContaining({
+        resetPasswordOtpVerified: true,
+        resetPasswordOtp: null,
+        resetPasswordOtpExpireAt: null,
+        resetPasswordOtpResendAvailableAt: null,
+      }),
+    });
+    expect(authUnitTestEnvironment.redisDel).toHaveBeenCalledWith(
+      "auth:reset-password:attempts:user_1",
+    );
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds end-to-end auth test coverage across the repo’s main auth surfaces and prepares the auth flow for CI/CD enforcement.

The auth stack is now covered at the right boundaries:
- HTTP route integration tests
- auth middleware integration tests
- GraphQL auth integration tests
- socket auth integration tests
- auth service unit tests
- auth worker integration tests

## What Changed

### HTTP auth integration
Covered the public and protected auth routes, including:
- register
- login
- oauth
- email verification
- resend verification email
- reset password request and verification
- change password
- session
- logout

These tests verify:
- request validation
- middleware behavior
- controller wiring
- response shape and status codes
- auth cookie handling

### Auth middleware integration
Added real middleware coverage for:
- `isAuthenticated`
- `requireLoggedOut`
- `isVerified`
- `requireActiveUser`
- `isAdmin`

These tests exercise auth gating without going through full controllers.

### GraphQL and socket auth integration
Added coverage for:
- GraphQL auth context/session bootstrap
- Socket.IO auth handshake/session bootstrap

### Auth service unit tests
Added unit tests for the auth service layer and shared auth helpers, covering:
- user registration and login behavior
- email verification and resend flows
- password reset flows
- password change
- session lookup
- OAuth register-or-login behavior
- expired unverified account cleanup logic
- account deletion logic

### Auth worker integration
Added worker-level integration tests for:
- unverified account cleanup worker
- account deletion worker
- email worker auth-related branches

To make those workers testable, the worker modules were refactored to export explicit start functions instead of only relying on import-time side effects.

### Shared test harnesses
Added reusable helpers under `tests/helpers/` for:
- app bootstrapping
- middleware test harnesses
- worker test harnesses
- deterministic auth mocks
- deterministic socket/GraphQL helpers

## Why This Matters

This gives us stable coverage for the auth system before CI is turned on:
- fast unit tests for business logic
- integration tests for real wiring and boundaries
- no reliance on live external services for the test suite itself

That means CI can enforce auth regressions reliably without needing full E2E coverage yet.

## Validation

Verified with:
- `npx tsc --noEmit --pretty false`
- auth unit suite
- auth HTTP integration suite
- auth middleware integration suite
- GraphQL auth integration suite
- socket auth integration suite
- auth worker integration suite

## Notes

Full E2E auth tests will be added later once the broader test suite is complete and CI is being finalized.

## Related

Closes #222 