### PR TITLE
Implement badge award worker flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev:accountDeletion-worker": "tsx src/workers/accountDeletion.worker.ts",
     "dev:moderationAudit-worker": "tsx src/workers/moderationAudit.worker.ts",
     "dev:notification-worker": "tsx src/workers/notification.worker.ts",
+    "dev:badge-worker": "tsx src/workers/badge.worker.ts",
     "dev:topicDetermination-worker": "tsx src/workers/topicDetermination.worker.ts",
     "dev:questionEmbedding-worker": "tsx src/workers/questionEmbedding.worker.ts",
     "dev:aiAnswer-worker": "tsx src/workers/aiAnswer.worker.ts",
@@ -39,7 +40,7 @@
     "dev:similarQuestions-worker": "tsx src/workers/similarQuestions.worker.ts",
     "dev:userInterest-worker": "tsx src/workers/userInterest.worker.ts",
     "dev:unverifiedAccountCleanup-worker": "tsx src/workers/unverifiedAccountCleanup.worker.ts",
-    "dev:all-workers": "concurrently \"npm run dev:email-worker\" \"npm run dev:contentModeration-worker\" \"npm run dev:questionVersioning-worker\" \"npm run dev:contentPipelineRouter-worker\" \"npm run dev:stats-worker\" \"npm run dev:imageModeration-worker\" \"npm run dev:contentFinalize-worker\" \"npm run dev:imageDeletion-worker\" \"npm run dev:moderationMetrics-worker\" \"npm run dev:deleteContent-worker\" \"npm run dev:accountDeletion-worker\" \"npm run dev:moderationAudit-worker\" \"npm run dev:notification-worker\" \"npm run dev:topicDetermination-worker\" \"npm run dev:questionEmbedding-worker\" \"npm run dev:aiAnswer-worker\" \"npm run dev:aiSuggestion-worker\" \"npm run dev:similarQuestions-worker\" \"npm run dev:userInterest-worker\" \"npm run dev:unverifiedAccountCleanup-worker\"",
+    "dev:all-workers": "concurrently \"npm run dev:email-worker\" \"npm run dev:contentModeration-worker\" \"npm run dev:questionVersioning-worker\" \"npm run dev:contentPipelineRouter-worker\" \"npm run dev:stats-worker\" \"npm run dev:imageModeration-worker\" \"npm run dev:contentFinalize-worker\" \"npm run dev:imageDeletion-worker\" \"npm run dev:moderationMetrics-worker\" \"npm run dev:deleteContent-worker\" \"npm run dev:accountDeletion-worker\" \"npm run dev:moderationAudit-worker\" \"npm run dev:notification-worker\" \"npm run dev:badge-worker\" \"npm run dev:topicDetermination-worker\" \"npm run dev:questionEmbedding-worker\" \"npm run dev:aiAnswer-worker\" \"npm run dev:aiSuggestion-worker\" \"npm run dev:similarQuestions-worker\" \"npm run dev:userInterest-worker\" \"npm run dev:unverifiedAccountCleanup-worker\"",
     "lint": "eslint src/**/*.{js,ts}",
     "format": "prettier --write 'src/**/*.{js,ts,json,md}'"
   },

--- a/src/graphql/resolvers/user.resolver.ts
+++ b/src/graphql/resolvers/user.resolver.ts
@@ -1,11 +1,13 @@
 import { mergeResolvers } from "@graphql-tools/merge";
 
 import commonScalarsResolver from "./common/scalars.resolver.js";
+import userBadgesResolver from "./user/user.badges.resolver.js";
 import userBaseResolver from "./user/user.base.resolver.js";
 import userNotificationsResolver from "./user/user.notifications.resolver.js";
 
 const userResolver = mergeResolvers([
   commonScalarsResolver,
+  userBadgesResolver,
   userBaseResolver,
   userNotificationsResolver,
 ]);

--- a/src/graphql/resolvers/user/user.badges.helper.ts
+++ b/src/graphql/resolvers/user/user.badges.helper.ts
@@ -1,0 +1,224 @@
+import { Redis } from "ioredis";
+
+import HttpError from "../../../utils/httpError.util.js";
+
+type UserBadgeCursor = {
+  awardedAt: string;
+  badgeId: string;
+};
+
+type UserBadgeRecord = {
+  badgeId: string;
+  name: string;
+  description: string | null;
+  iconKey: string | null;
+  colorKey: string | null;
+  imageKey: string | null;
+  isActive: boolean;
+  awardedAt: string;
+  source: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type CachedUserBadgePage = {
+  badges: UserBadgeRecord[];
+  nextCursor: UserBadgeCursor | null;
+  hasMore: boolean;
+};
+
+type UserBadgePage = CachedUserBadgePage;
+
+type UserBadgesContext = {
+  userId: string;
+  cursor?: UserBadgeCursor;
+  limitCount: number;
+  prisma: any;
+  getRedisCacheClient: () => Redis;
+};
+
+type UserBadgeAssignment = {
+  badgeId: string;
+  awardedAt: Date;
+  source: string | null;
+};
+
+type BadgeDetails = {
+  id: string;
+  name: string;
+  description: string | null;
+  iconKey: string | null;
+  colorKey: string | null;
+  imageKey: string | null;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const DEFAULT_LIMIT_COUNT = 5;
+const CACHE_TTL_SECONDS = 60 * 15;
+
+const normalizeLimitCount = (limitCount: number) =>
+  Number.isInteger(limitCount) && Number(limitCount) > 0
+    ? Number(limitCount)
+    : DEFAULT_LIMIT_COUNT;
+
+const buildUserBadgesCacheKey = (
+  userId: string,
+  cursor: UserBadgeCursor | undefined,
+  limitCount: number,
+) => {
+  const cursorCacheKey = cursor
+    ? `${cursor.awardedAt}:${cursor.badgeId}`
+    : "initial";
+
+  return `user:badges:${userId}:${cursorCacheKey}:${limitCount}`;
+};
+
+const validateCursor = (cursor: UserBadgeCursor) => {
+  if (!cursor.badgeId || Number.isNaN(Date.parse(cursor.awardedAt))) {
+    throw new HttpError("Invalid cursor", 400);
+  }
+};
+
+const parseCachedPage = (cachedPage: string): CachedUserBadgePage =>
+  JSON.parse(cachedPage) as CachedUserBadgePage;
+
+const mapBadgeRecord = (
+  assignment: UserBadgeAssignment,
+  badge: BadgeDetails,
+): UserBadgeRecord => ({
+  badgeId: assignment.badgeId,
+  name: badge.name,
+  description: badge.description,
+  iconKey: badge.iconKey,
+  colorKey: badge.colorKey,
+  imageKey: badge.imageKey,
+  isActive: badge.isActive,
+  awardedAt: assignment.awardedAt.toISOString(),
+  source: assignment.source,
+  createdAt: badge.createdAt.toISOString(),
+  updatedAt: badge.updatedAt.toISOString(),
+});
+
+const getUserBadges = async ({
+  userId,
+  cursor,
+  limitCount,
+  prisma,
+  getRedisCacheClient,
+}: UserBadgesContext): Promise<UserBadgePage> => {
+  const normalizedLimitCount = normalizeLimitCount(limitCount);
+
+  if (cursor) {
+    validateCursor(cursor);
+  }
+
+  const cacheKey = buildUserBadgesCacheKey(
+    userId,
+    cursor,
+    normalizedLimitCount,
+  );
+
+  const cachedBadges = await getRedisCacheClient().get(cacheKey);
+  if (cachedBadges) {
+    return parseCachedPage(cachedBadges);
+  }
+
+  const userBadgeAssignments = (await prisma.userBadge.findMany({
+    where: {
+      userId,
+      ...(cursor
+        ? {
+            OR: [
+              {
+                awardedAt: {
+                  lt: new Date(cursor.awardedAt),
+                },
+              },
+              {
+                awardedAt: new Date(cursor.awardedAt),
+                badgeId: {
+                  lt: cursor.badgeId,
+                },
+              },
+            ],
+          }
+        : {}),
+    },
+    orderBy: [{ awardedAt: "desc" }, { badgeId: "desc" }],
+    take: normalizedLimitCount + 1,
+    select: {
+      badgeId: true,
+      awardedAt: true,
+      source: true,
+    },
+  })) as UserBadgeAssignment[];
+
+  const hasMore = userBadgeAssignments.length > normalizedLimitCount;
+  const slicedAssignments = userBadgeAssignments.slice(0, normalizedLimitCount);
+
+  const badgeIds = slicedAssignments.map(({ badgeId }) => badgeId);
+  const userBadgeByBadgeId = new Map(
+    slicedAssignments.map((assignment) => [assignment.badgeId, assignment]),
+  );
+
+  const badges = badgeIds.length
+    ? ((await prisma.badge.findMany({
+        where: {
+          id: {
+            in: badgeIds,
+          },
+        },
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          iconKey: true,
+          colorKey: true,
+          imageKey: true,
+          isActive: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      })) as BadgeDetails[])
+    : [];
+
+  const badgeById = new Map(badges.map((badge) => [badge.id, badge]));
+  const mergedBadges: UserBadgeRecord[] = [];
+
+  for (const badgeId of badgeIds) {
+    const assignment = userBadgeByBadgeId.get(badgeId);
+    const badge = badgeById.get(badgeId);
+
+    if (!assignment || !badge) {
+      continue;
+    }
+
+    mergedBadges.push(mapBadgeRecord(assignment, badge));
+  }
+
+  const lastBadge = mergedBadges[mergedBadges.length - 1];
+  const result = {
+    badges: mergedBadges,
+    nextCursor:
+      hasMore && lastBadge
+        ? {
+            awardedAt: lastBadge.awardedAt,
+            badgeId: lastBadge.badgeId,
+          }
+        : null,
+    hasMore,
+  } satisfies UserBadgePage;
+
+  await getRedisCacheClient().set(
+    cacheKey,
+    JSON.stringify(result),
+    "EX",
+    CACHE_TTL_SECONDS,
+  );
+
+  return result;
+};
+
+export { getUserBadges, type UserBadgeCursor, type UserBadgePage };

--- a/src/graphql/resolvers/user/user.badges.resolver.ts
+++ b/src/graphql/resolvers/user/user.badges.resolver.ts
@@ -1,0 +1,43 @@
+import { Redis } from "ioredis";
+
+import { User } from "../../../generated/prisma/index.js";
+
+import {
+  type UserBadgeCursor,
+  type UserBadgePage,
+  getUserBadges,
+} from "./user.badges.helper.js";
+
+const userBadgesResolver = {
+  Query: {
+    badges: async (
+      _: any,
+      {
+        cursor,
+        limitCount = 5,
+      }: {
+        cursor?: UserBadgeCursor;
+        limitCount: number;
+      },
+      {
+        user,
+        prisma,
+        getRedisCacheClient,
+      }: {
+        user: User;
+        prisma: any;
+        getRedisCacheClient: () => Redis;
+      },
+    ): Promise<UserBadgePage> => {
+      return getUserBadges({
+        userId: user.id,
+        cursor,
+        limitCount,
+        prisma,
+        getRedisCacheClient,
+      });
+    },
+  },
+};
+
+export default userBadgesResolver;

--- a/src/graphql/typeDefs/user.typeDefs.ts
+++ b/src/graphql/typeDefs/user.typeDefs.ts
@@ -1,10 +1,12 @@
 import { mergeTypeDefs } from "@graphql-tools/merge";
 
+import userBadgesTypeDefs from "./user/user.badges.typeDefs.js";
 import userBaseTypeDefs from "./user/user.base.typeDefs.js";
 import userEnumsTypeDefs from "./user/user.enums.typeDefs.js";
 import userNotificationsTypeDefs from "./user/user.notifications.typeDefs.js";
 
 const userTypeDefs = mergeTypeDefs([
+  userBadgesTypeDefs,
   userEnumsTypeDefs,
   userBaseTypeDefs,
   userNotificationsTypeDefs,

--- a/src/graphql/typeDefs/user/user.badges.typeDefs.ts
+++ b/src/graphql/typeDefs/user/user.badges.typeDefs.ts
@@ -1,0 +1,39 @@
+import { gql } from "graphql-tag";
+
+const userBadgesTypeDefs = gql`
+  type UserBadge {
+    badgeId: String!
+    name: String!
+    description: String
+    iconKey: String
+    colorKey: String
+    imageKey: String
+    isActive: Boolean!
+    awardedAt: String!
+    source: String
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  type UserBadgeConnection {
+    badges: [UserBadge!]!
+    nextCursor: UserBadgeCursor
+    hasMore: Boolean!
+  }
+
+  type UserBadgeCursor {
+    awardedAt: String!
+    badgeId: String!
+  }
+
+  input UserBadgeCursorInput {
+    awardedAt: String!
+    badgeId: String!
+  }
+
+  extend type Query {
+    badges(cursor: UserBadgeCursorInput, limitCount: Int): UserBadgeConnection!
+  }
+`;
+
+export default userBadgesTypeDefs;

--- a/src/queues/badge.queue.ts
+++ b/src/queues/badge.queue.ts
@@ -1,0 +1,8 @@
+import { Queue } from "bullmq";
+import { redisMessagingClientConnection } from "../config/redis.config.js";
+
+const badgeQueue = new Queue("badgeQueue", {
+  connection: redisMessagingClientConnection,
+});
+
+export default badgeQueue;

--- a/src/services/auth/deleteAccount.service.ts
+++ b/src/services/auth/deleteAccount.service.ts
@@ -9,7 +9,10 @@ import deleteSingleImageService from "../media/deleteSingleImage.service.js";
 
 import buildDeletedUserData from "../../utils/buildDeletedUserData.util.js";
 
-import { clearNotificationCache } from "../../utils/clearCache.util.js";
+import {
+  clearNotificationCache,
+  clearUserBadgesCache,
+} from "../../utils/clearCache.util.js";
 
 type DeleteAccountJobData = {
   userId: string;
@@ -37,6 +40,7 @@ const purgeAccountData = async ({
     prisma.ban.deleteMany({ where: { userId } }),
     prisma.moderationStats.deleteMany({ where: { userId } }),
     prisma.notificationSettings.deleteMany({ where: { userId } }),
+    prisma.userBadge.deleteMany({ where: { userId } }),
   ]);
 
   await Notification.deleteMany({
@@ -47,6 +51,7 @@ const purgeAccountData = async ({
 
   await getRedisCacheClient().del(`user:${userId}`);
   await clearNotificationCache(userId);
+  await clearUserBadgesCache(userId);
 };
 
 const softDeleteAccount = async (userId: string) => {

--- a/src/services/auth/register.service.ts
+++ b/src/services/auth/register.service.ts
@@ -1,13 +1,5 @@
 import bcrypt from "bcrypt";
 
-import prisma from "../../config/prisma.config.js";
-
-import emailQueue from "../../queues/email.queue.js";
-
-import HttpError from "../../utils/httpError.util.js";
-import { makeUniqueJobId } from "../../utils/makeJobId.util.js";
-import { verificationHtml } from "../../utils/renderTemplate.util.js";
-
 import {
   cacheUser,
   getDeviceIp,
@@ -15,6 +7,16 @@ import {
   handleExpiredUnverifiedUser,
   type DeviceInfo,
 } from "./auth.shared.js";
+
+import queueBadgeAward from "../user/badge/queueBadgeAward.service.js";
+
+import prisma from "../../config/prisma.config.js";
+
+import HttpError from "../../utils/httpError.util.js";
+import { makeUniqueJobId } from "../../utils/makeJobId.util.js";
+import { verificationHtml } from "../../utils/renderTemplate.util.js";
+
+import emailQueue from "../../queues/email.queue.js";
 
 type RegisterInput = {
   username: string;
@@ -77,6 +79,8 @@ const register = async ({
   });
 
   await cacheUser(newUser);
+
+  await queueBadgeAward({ userId: newUser.id });
 
   const deviceName = `${deviceInfo.browser} on ${deviceInfo.os}`;
   const htmlContent = verificationHtml(

--- a/src/services/auth/registerOrLogin.service.ts
+++ b/src/services/auth/registerOrLogin.service.ts
@@ -1,14 +1,15 @@
-import HttpError from "../../utils/httpError.util.js";
-import generateOAuthUsername from "../../utils/generateOAuthUsername.util.js";
-import verifyGoogleToken from "../../utils/verifyGoogleToken.util.js";
-
-import prisma from "../../config/prisma.config.js";
-
 import {
   cacheUser,
   getRegisteredStage,
   handleExpiredUnverifiedUser,
 } from "./auth.shared.js";
+import queueBadgeAward from "../user/badge/queueBadgeAward.service.js";
+
+import prisma from "../../config/prisma.config.js";
+
+import HttpError from "../../utils/httpError.util.js";
+import generateOAuthUsername from "../../utils/generateOAuthUsername.util.js";
+import verifyGoogleToken from "../../utils/verifyGoogleToken.util.js";
 
 type OAuthInput =
   | {
@@ -56,6 +57,8 @@ const registerOrLogin = async (input: OAuthInput) => {
 
       await cacheUser(newUser);
 
+      await queueBadgeAward({ userId: newUser.id });
+
       return { user: newUser, action: "registered" as const };
     }
 
@@ -101,6 +104,8 @@ const registerOrLogin = async (input: OAuthInput) => {
     });
 
     await cacheUser(newUser);
+
+    await queueBadgeAward({ userId: newUser.id });
 
     return { user: newUser, action: "registered" as const };
   }

--- a/src/services/user/badge/awardBadge.service.ts
+++ b/src/services/user/badge/awardBadge.service.ts
@@ -1,0 +1,75 @@
+import type { BadgeTrigger } from "./badge.shared.js";
+import { getBadgeRulesForTrigger } from "./rules/index.js";
+
+import prisma from "../../../config/prisma.config.js";
+
+type AwardBadgeInput = {
+  userId: string;
+  trigger: BadgeTrigger;
+};
+
+const awardBadge = async ({ userId, trigger }: AwardBadgeInput) => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      registeredStage: true,
+      isDeleted: true,
+    },
+  });
+
+  if (!user || user.isDeleted) {
+    throw new Error(`Badge user not found: ${userId}`);
+  }
+
+  const rules = getBadgeRulesForTrigger(trigger);
+
+  if (!rules.length) {
+    throw new Error(`Unsupported badge trigger: ${trigger}`);
+  }
+
+  for (const rule of rules) {
+    const shouldAward = await rule.shouldAward({
+      trigger,
+      user,
+    });
+
+    if (!shouldAward) {
+      continue;
+    }
+
+    const badge = await prisma.badge.findFirst({
+      where: {
+        name: rule.badgeName,
+        isActive: true,
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+
+    if (!badge) {
+      throw new Error(`Badge not found: ${rule.badgeName}`);
+    }
+
+    await prisma.userBadge.upsert({
+      where: {
+        userId_badgeId: {
+          userId: user.id,
+          badgeId: badge.id,
+        },
+      },
+      create: {
+        userId: user.id,
+        badgeId: badge.id,
+        source: trigger,
+      },
+      update: {
+        source: trigger,
+      },
+    });
+  }
+};
+
+export default awardBadge;

--- a/src/services/user/badge/awardBadge.service.ts
+++ b/src/services/user/badge/awardBadge.service.ts
@@ -3,6 +3,8 @@ import { getBadgeRulesForTrigger } from "./rules/index.js";
 
 import prisma from "../../../config/prisma.config.js";
 
+import { clearUserBadgesCache } from "../../../utils/clearCache.util.js";
+
 type AwardBadgeInput = {
   userId: string;
   trigger: BadgeTrigger;
@@ -69,6 +71,8 @@ const awardBadge = async ({ userId, trigger }: AwardBadgeInput) => {
         source: trigger,
       },
     });
+
+    await clearUserBadgesCache(user.id);
   }
 };
 

--- a/src/services/user/badge/badge.shared.ts
+++ b/src/services/user/badge/badge.shared.ts
@@ -1,0 +1,31 @@
+import type { User } from "../../../generated/prisma/index.js";
+
+const badgeTriggers = {
+  ACCOUNT_CREATED: "ACCOUNT_CREATED",
+} as const;
+
+const FOUNDING_MEMBER_BADGE_NAME = "Founding Member";
+const FOUNDING_MEMBER_ELIGIBLE_STAGES = new Set(["demo", "beta", "alpha"]);
+
+const normalizeBadgeStage = (stage: string) => stage.trim().toLowerCase();
+
+type BadgeTrigger = (typeof badgeTriggers)[keyof typeof badgeTriggers];
+
+type BadgeRuleContext = {
+  trigger: BadgeTrigger;
+  user: Pick<User, "id" | "registeredStage">;
+};
+
+type BadgeRule = {
+  badgeName: string;
+  triggers: BadgeTrigger[];
+  shouldAward: (context: BadgeRuleContext) => boolean | Promise<boolean>;
+};
+
+export {
+  badgeTriggers,
+  FOUNDING_MEMBER_BADGE_NAME,
+  FOUNDING_MEMBER_ELIGIBLE_STAGES,
+  normalizeBadgeStage,
+};
+export type { BadgeRule, BadgeRuleContext, BadgeTrigger };

--- a/src/services/user/badge/queueBadgeAward.service.ts
+++ b/src/services/user/badge/queueBadgeAward.service.ts
@@ -1,0 +1,29 @@
+import { badgeTriggers, type BadgeTrigger } from "./badge.shared.js";
+
+import { makeJobId } from "../../../utils/makeJobId.util.js";
+
+import badgeQueue from "../../../queues/badge.queue.js";
+
+type QueueBadgeAwardInput = {
+  userId: string;
+  trigger?: BadgeTrigger;
+};
+
+const queueBadgeAward = async ({
+  userId,
+  trigger = badgeTriggers.ACCOUNT_CREATED,
+}: QueueBadgeAwardInput) => {
+  await badgeQueue.add(
+    trigger,
+    {
+      userId,
+    },
+    {
+      removeOnComplete: true,
+      removeOnFail: false,
+      jobId: makeJobId("badge", trigger, userId),
+    },
+  );
+};
+
+export default queueBadgeAward;

--- a/src/services/user/badge/rules/foundingMember.rule.ts
+++ b/src/services/user/badge/rules/foundingMember.rule.ts
@@ -1,0 +1,18 @@
+import {
+  badgeTriggers,
+  FOUNDING_MEMBER_BADGE_NAME,
+  FOUNDING_MEMBER_ELIGIBLE_STAGES,
+  normalizeBadgeStage,
+  type BadgeRule,
+} from "../badge.shared.js";
+
+const foundingMemberRule: BadgeRule = {
+  badgeName: FOUNDING_MEMBER_BADGE_NAME,
+  triggers: [badgeTriggers.ACCOUNT_CREATED],
+  shouldAward: ({ user }) =>
+    FOUNDING_MEMBER_ELIGIBLE_STAGES.has(
+      normalizeBadgeStage(user.registeredStage),
+    ),
+};
+
+export default foundingMemberRule;

--- a/src/services/user/badge/rules/index.ts
+++ b/src/services/user/badge/rules/index.ts
@@ -1,0 +1,10 @@
+import type { BadgeRule, BadgeTrigger } from "../badge.shared.js";
+
+import foundingMemberRule from "./foundingMember.rule.js";
+
+const badgeRules: BadgeRule[] = [foundingMemberRule];
+
+const getBadgeRulesForTrigger = (trigger: BadgeTrigger) =>
+  badgeRules.filter((rule) => rule.triggers.includes(trigger));
+
+export { badgeRules, getBadgeRulesForTrigger };

--- a/src/services/user/deleteAccount.service.ts
+++ b/src/services/user/deleteAccount.service.ts
@@ -1,4 +1,7 @@
-import { clearNotificationCache } from "../../utils/clearCache.util.js";
+import {
+  clearNotificationCache,
+  clearUserBadgesCache,
+} from "../../utils/clearCache.util.js";
 import { makeJobId } from "../../utils/makeJobId.util.js";
 import HttpError from "../../utils/httpError.util.js";
 import buildDeletedUserData from "../../utils/buildDeletedUserData.util.js";
@@ -71,6 +74,7 @@ const deleteAccount = async ({ userId }: DeleteAccountInput) => {
   );
   await getRedisCacheClient().del(`auth:user:${userId}`);
   await clearNotificationCache(userId);
+  await clearUserBadgesCache(userId);
   await publishSocketDisconnect(userId);
 
   await accountDeletionQueue.add(

--- a/src/utils/clearCache.util.ts
+++ b/src/utils/clearCache.util.ts
@@ -39,8 +39,13 @@ async function clearNotificationCache(userId: string) {
   await deleteKeysByPattern(`notifications:${userId}:*`);
 }
 
+async function clearUserBadgesCache(userId: string) {
+  await deleteKeysByPattern(`user:badges:${userId}:*`);
+}
+
 export {
   clearAnswerCache,
+  clearUserBadgesCache,
   clearReplyCache,
   clearVersionHistoryCache,
   clearReportsCache,

--- a/src/workers/badge.worker.ts
+++ b/src/workers/badge.worker.ts
@@ -1,0 +1,70 @@
+import { Worker } from "bullmq";
+import { fileURLToPath } from "node:url";
+
+import awardBadge from "../services/user/badge/awardBadge.service.js";
+import {
+  badgeTriggers,
+  type BadgeTrigger,
+} from "../services/user/badge/badge.shared.js";
+
+import { redisMessagingClientConnection } from "../config/redis.config.js";
+
+const workerFilePath = fileURLToPath(import.meta.url);
+
+const isBadgeTrigger = (value: string): value is BadgeTrigger =>
+  Object.values(badgeTriggers).includes(value as BadgeTrigger);
+
+async function startBadgeWorker() {
+  console.log("Starting badge worker...");
+
+  const worker = new Worker(
+    "badgeQueue",
+    async (job) => {
+      if (!isBadgeTrigger(job.name)) {
+        throw new Error(`Unsupported badge trigger: ${job.name}`);
+      }
+
+      const { userId } = job.data as {
+        userId: string;
+      };
+
+      return awardBadge({
+        userId,
+        trigger: job.name,
+      });
+    },
+    {
+      connection: redisMessagingClientConnection,
+      concurrency: 5,
+      limiter: {
+        max: 20,
+        duration: 1000,
+      },
+    },
+  );
+
+  worker.on("completed", (job) => {
+    console.log(`Job ${job.id} completed`);
+  });
+
+  worker.on("failed", (job, err) => {
+    console.error(`Job ${job?.id} failed:`, err);
+  });
+
+  worker.on("error", (err) => {
+    console.error("Worker crashed:", err);
+  });
+
+  return worker;
+}
+
+const isDirectRun = process.argv[1] === workerFilePath;
+
+if (isDirectRun) {
+  void startBadgeWorker().catch((error) => {
+    console.error("Failed to start badge worker:", error);
+    process.exit(1);
+  });
+}
+
+export { startBadgeWorker };


### PR DESCRIPTION
# Badges Feature Summary

## What This Adds

This change adds a user badges feature across the backend:

- badge award infrastructure under `src/services/user/badge/`
- a BullMQ badge worker and queue flow for asynchronous badge awarding
- badge persistence through `Badge` and `UserBadge` Prisma models
- a GraphQL `badges` query that returns the authenticated user's badges
- Redis caching for badge query results
- cache invalidation when badge assignments are upserted
- badge cleanup during account deletion

## GraphQL Behavior

The new GraphQL query returns a paginated badge connection for the authenticated user:

- query: `badges(cursor, limitCount)`
- default page size: `5`
- sort order: `awardedAt desc`, then `badgeId desc`
- payload combines:
  - `awardedAt` and `source` from `UserBadge`
  - badge metadata such as `name`, `description`, `iconKey`, `colorKey`, `imageKey`, `isActive`, `createdAt`, and `updatedAt` from `Badge`

Redis is checked first for cached pages. If no cached entry exists, the backend reads `UserBadge`, fetches the corresponding `Badge` records, builds the merged response, caches it, and returns it.

## Deletion Behavior

Account deletion now also covers badge-related data:

- badge query cache is cleared when account deletion is requested
- `UserBadge` assignments are hard-deleted during account data purge
- badge query cache is cleared again during purge for consistency

## Scope Note

Automated testing for this feature is intentionally not part of this PR.

Test coverage, integration validation, and any follow-up test harness work will be handled in a future PR. This change is limited to delivering the feature implementation and the related cache and deletion behavior.

Closes #231
